### PR TITLE
Document why the reload does not suppress its play/pause

### DIFF
--- a/src/services/playback-controls.ts
+++ b/src/services/playback-controls.ts
@@ -88,9 +88,17 @@ export async function startFreshPlaythrough(session: Session, mediaId: string) {
 /**
  * Reload the currently loaded playthrough if it matches the given mediaId.
  *
- * This is used when switching between streaming and downloaded audio.
- * The reload is "smooth" - no pause/play events are recorded and no seek-back
- * happens. The player just switches to the new source at the same position.
+ * Used when switching between streaming and downloaded audio. The player picks
+ * up the new source at the same position, with no seek-back: the rewind is
+ * applied by callers of `pause()`, and the reload resets TrackPlayer directly.
+ *
+ * It deliberately does *not* tag its play/pause as INTERNAL, which would
+ * suppress them. The reset emits a pause and the resume emits a play; when the
+ * reload succeeds those two cancel out in the accumulation window and nothing
+ * is recorded. When it fails - the download was deleted and the stream cannot
+ * be reached, say - the resume never lands, so only the pause survives and a
+ * genuine pause is recorded and the heartbeat stops. Suppressing the pair would
+ * leave the event log claiming playback continued while the audio was silent.
  */
 export async function reloadCurrentPlaythroughIfMedia(
   session: Session,

--- a/src/services/track-player-service.ts
+++ b/src/services/track-player-service.ts
@@ -370,6 +370,15 @@ export async function loadPlaythroughIntoPlayer(
  *
  * This is used for seamless switching between streaming and downloaded content
  * (or vice versa) when the underlying media source changes.
+ *
+ * Note that this calls TrackPlayer directly rather than going through `play()`
+ * and `pause()`, so the resulting transitions are reported as EXTERNAL rather
+ * than INTERNAL. That is deliberate, not an oversight: routing it through the
+ * wrappers would tag the pair INTERNAL and suppress it, which is only correct
+ * while the reload succeeds. If the new source cannot be played - the download
+ * was deleted and the device is offline, say - the resume never lands, and the
+ * unsuppressed pause is what records that playback actually stopped and stops
+ * the position heartbeat. See `reloadCurrentPlaythroughIfMedia`.
  */
 export async function reloadCurrentPlaythrough(
   session: Session,


### PR DESCRIPTION
Comments only, no behaviour change.

`reloadCurrentPlaythroughIfMedia`'s docstring claimed the reload records no pause/play events. That's only half true, and it pointed squarely at a "fix" that would have been a regression — I nearly made it.

`reloadCurrentPlaythrough` calls TrackPlayer directly rather than going through `play()`/`pause()`, so its transitions are reported as `EXTERNAL` rather than `INTERNAL`.

- **Reload succeeds:** the reset emits a pause and the resume emits a play. Both land in the same `PLAY_PAUSE_EVENT_ACCUMULATION_WINDOW`, `flushPlayPauseEvent` sees `stateBefore === finalState`, and nothing is recorded. This is the case the docstring described.
- **Reload fails** — the download was deleted and the device is offline, so the stream can't be reached: `play()` is called but `isPlaying` never becomes true, so no play event fires. Only the pause survives, a genuine pause is recorded, and the position heartbeat stops.

That second case is the one that matters, and it's why the pair must *not* be tagged `INTERNAL`. Suppressing it would leave the event log asserting playback continued — and the heartbeat still writing positions — while the audio was silent.

Also worth noting the "no seek-back" half of the docstring is accurate and stays accurate: `PAUSE_REWIND_SECONDS` is passed explicitly at each `pause()` call site, and the reload resets TrackPlayer directly, bypassing the wrapper.

Notes added in both places: the docstring itself, and above `reloadCurrentPlaythrough` where someone would actually be tempted to route it through the wrappers.