### PR TITLE
Fix sync gaps on fresh login, empty library, and Force Full Sync

### DIFF
--- a/src/app/(tabs)/(home)/(settings)/settings.ios.tsx
+++ b/src/app/(tabs)/(home)/(settings)/settings.ios.tsx
@@ -94,8 +94,11 @@ export default function SettingsRoute() {
 
   const handleForceFullSync = useCallback(async () => {
     if (!session) return;
-    await sync(session, { fullEventResync: true });
-    Alert.alert("Sync Complete", "Full event sync has been completed.");
+    await sync(session, { fullEventResync: true, fullLibraryResync: true });
+    Alert.alert(
+      "Sync Complete",
+      "The library and all playback events have been re-synced.",
+    );
   }, [session]);
 
   if (!session) return null;

--- a/src/app/(tabs)/(home)/(settings)/settings.tsx
+++ b/src/app/(tabs)/(home)/(settings)/settings.tsx
@@ -1,6 +1,13 @@
 // Android version (default) - uses Jetpack Compose Switch + React Native layout
-import { useCallback } from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useCallback, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  ToastAndroid,
+  View,
+} from "react-native";
 import Animated from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Host, Switch } from "@expo/ui/jetpack-compose";
@@ -26,6 +33,10 @@ import { formatPlaybackRate } from "@/utils/rate";
 
 const switchColors = {
   checkedTrackColor: Colors.lime[500],
+};
+
+const rowRipple = {
+  color: Colors.zinc[700],
 };
 
 export default function SettingsRoute() {
@@ -70,10 +81,20 @@ export default function SettingsRoute() {
     [session],
   );
 
+  const [syncing, setSyncing] = useState(false);
+
   const handleForceFullSync = useCallback(async () => {
-    if (!session) return;
-    await sync(session, { fullEventResync: true });
-  }, [session]);
+    if (!session || syncing) return;
+    setSyncing(true);
+    try {
+      await sync(session, { fullEventResync: true, fullLibraryResync: true });
+      ToastAndroid.show("Sync complete", ToastAndroid.SHORT);
+    } catch {
+      ToastAndroid.show("Sync failed", ToastAndroid.SHORT);
+    } finally {
+      setSyncing(false);
+    }
+  }, [session, syncing]);
 
   if (!session) return null;
 
@@ -111,7 +132,11 @@ export default function SettingsRoute() {
                 </Text>
               </View>
               <View style={styles.divider} />
-              <Pressable style={styles.row} onPress={handleSignOut}>
+              <Pressable
+                style={styles.row}
+                android_ripple={rowRipple}
+                onPress={handleSignOut}
+              >
                 <Text style={styles.destructiveText}>Sign Out</Text>
               </Pressable>
             </View>
@@ -121,7 +146,11 @@ export default function SettingsRoute() {
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>Playback</Text>
             <View style={styles.card}>
-              <Pressable style={styles.row} onPress={openPlaybackRateSettings}>
+              <Pressable
+                style={styles.row}
+                android_ripple={rowRipple}
+                onPress={openPlaybackRateSettings}
+              >
                 <View style={styles.rowLabelContainer}>
                   <Text style={styles.rowLabel}>Default Speed</Text>
                   <Text style={styles.rowDescription}>
@@ -140,7 +169,11 @@ export default function SettingsRoute() {
                 </View>
               </Pressable>
               <View style={styles.divider} />
-              <Pressable style={styles.row} onPress={openSleepTimerSettings}>
+              <Pressable
+                style={styles.row}
+                android_ripple={rowRipple}
+                onPress={openSleepTimerSettings}
+              >
                 <View style={styles.rowLabelContainer}>
                   <Text style={styles.rowLabel}>Sleep Timer</Text>
                   <Text style={styles.rowDescription}>
@@ -195,8 +228,18 @@ export default function SettingsRoute() {
                 </Host>
               </View>
               <View style={styles.divider} />
-              <Pressable style={styles.row} onPress={handleForceFullSync}>
-                <Text style={styles.rowLabel}>Force Full Sync</Text>
+              <Pressable
+                style={styles.row}
+                android_ripple={rowRipple}
+                onPress={handleForceFullSync}
+                disabled={syncing}
+              >
+                <Text style={styles.rowLabel}>
+                  {syncing ? "Syncing…" : "Force Full Sync"}
+                </Text>
+                {syncing && (
+                  <ActivityIndicator size="small" color={Colors.zinc[400]} />
+                )}
               </Pressable>
             </View>
           </View>

--- a/src/components/screens/library-screen/FullLibrary.tsx
+++ b/src/components/screens/library-screen/FullLibrary.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { Platform, StyleSheet, Text, View } from "react-native";
+import { Platform, RefreshControl, StyleSheet, Text, View } from "react-native";
 import { useKeyboardState } from "react-native-keyboard-controller";
 import Animated from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -88,11 +88,22 @@ export function FullLibrary({
 
   if (media.length === 0) {
     return (
-      <View
-        style={[
+      <Animated.ScrollView
+        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={[
           styles.emptyContainer,
           topInset > 0 && { paddingTop: topInset },
         ]}
+        showsVerticalScrollIndicator={false}
+        onScroll={scrollHandler}
+        scrollEventThrottle={16}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            progressViewOffset={topInset}
+          />
+        }
       >
         <FontAwesome6
           name="book-open"
@@ -105,7 +116,7 @@ export function FullLibrary({
           Log into your Ambry server on the web and add some audiobooks to get
           started.
         </Text>
-      </View>
+      </Animated.ScrollView>
     );
   }
 
@@ -148,7 +159,7 @@ export function FullLibrary({
 
 const styles = StyleSheet.create({
   emptyContainer: {
-    flex: 1,
+    flexGrow: 1,
     alignItems: "center",
     justifyContent: "center",
     paddingHorizontal: 48,

--- a/src/services/__tests__/auth-service.test.ts
+++ b/src/services/__tests__/auth-service.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for the auth service.
+ *
+ * Uses Detroit-style testing: we mock only:
+ * - Native modules (expo-secure-store, expo-file-system, etc.)
+ * - Network boundary (fetch)
+ *
+ * The real auth service, GraphQL API, and stores run.
+ */
+
+import { signOut } from "@/services/auth-service";
+import { useDataVersion } from "@/stores/data-version";
+import { useDownloads } from "@/stores/downloads";
+import {
+  resetForTesting as resetSessionStore,
+  useSession,
+} from "@/stores/session";
+import { setupTestDatabase } from "@test/db-test-utils";
+import { DEFAULT_TEST_SESSION } from "@test/factories";
+import {
+  graphqlSuccess,
+  installFetchMock,
+  mockGraphQL,
+} from "@test/fetch-mock";
+
+setupTestDatabase();
+
+describe("signOut", () => {
+  let mockFetch: ReturnType<typeof installFetchMock>;
+
+  beforeEach(() => {
+    mockFetch = installFetchMock();
+    resetSessionStore();
+    useSession.setState({ session: DEFAULT_TEST_SESSION });
+  });
+
+  it("clears the session and resets session-scoped stores", async () => {
+    mockGraphQL(
+      mockFetch,
+      graphqlSuccess({ deleteSession: { deleted: true } }),
+    );
+
+    // Simulate a previous session having initialized these stores; the JS
+    // context can outlive a sign-out, so they must be reset explicitly
+    useDataVersion.setState({
+      initialized: true,
+      libraryDataVersion: Date.parse("2024-01-15T10:00:00.000Z"),
+    });
+    useDownloads.setState({ initialized: true });
+
+    await signOut();
+
+    expect(useSession.getState().session).toBeNull();
+    expect(useDataVersion.getState().initialized).toBe(false);
+    expect(useDataVersion.getState().libraryDataVersion).toBeNull();
+    expect(useDownloads.getState().initialized).toBe(false);
+    expect(useDownloads.getState().downloads).toEqual({});
+  });
+});

--- a/src/services/__tests__/library-service.test.ts
+++ b/src/services/__tests__/library-service.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the library service hooks.
+ *
+ * usePaginatedLibraryData is exercised with a caller-supplied getPage function
+ * (its normal usage) backed by a plain in-memory array standing in for the
+ * database queries.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+
+import { usePaginatedLibraryData } from "@/services/library-service";
+import {
+  resetForTesting as resetDataVersionStore,
+  setLibraryDataVersion,
+} from "@/stores/data-version";
+import { setupTestDatabase } from "@test/db-test-utils";
+
+setupTestDatabase();
+
+type Row = { id: string; insertedAt: Date };
+
+describe("usePaginatedLibraryData", () => {
+  beforeEach(() => {
+    resetDataVersionStore();
+  });
+
+  it("reloads at least one page after a sync when the list was empty", async () => {
+    let rows: Row[] = [];
+    const getPage = async (pageSize: number, _cursor?: Date) =>
+      rows.slice(0, pageSize);
+    const getCursor = (item: Row) => item.insertedAt;
+
+    const { result } = renderHook(() =>
+      usePaginatedLibraryData(25, getPage, getCursor),
+    );
+
+    // Initial load against an empty database
+    await waitFor(() => {
+      expect(result.current.items).toEqual([]);
+    });
+
+    // A sync inserts rows and bumps the library data version
+    rows = [
+      { id: "media-1", insertedAt: new Date("2024-01-15T10:00:00.000Z") },
+      { id: "media-2", insertedAt: new Date("2024-01-15T11:00:00.000Z") },
+    ];
+    act(() => {
+      setLibraryDataVersion(new Date("2024-01-15T12:00:00.000Z"));
+    });
+
+    // The screen must pick up the new rows even though it had zero items
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(2);
+    });
+  });
+
+  it("reloads all currently loaded items when the data version changes", async () => {
+    let rows: Row[] = [
+      { id: "media-1", insertedAt: new Date("2024-01-15T10:00:00.000Z") },
+    ];
+    const getPage = async (pageSize: number, _cursor?: Date) =>
+      rows.slice(0, pageSize);
+    const getCursor = (item: Row) => item.insertedAt;
+
+    const { result } = renderHook(() =>
+      usePaginatedLibraryData(25, getPage, getCursor),
+    );
+
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(1);
+    });
+
+    rows = [
+      { id: "media-1", insertedAt: new Date("2024-01-15T10:00:00.000Z") },
+      { id: "media-2", insertedAt: new Date("2024-01-15T11:00:00.000Z") },
+    ];
+    act(() => {
+      setLibraryDataVersion(new Date("2024-01-15T12:00:00.000Z"));
+    });
+
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(2);
+    });
+  });
+});

--- a/src/services/__tests__/sync-hooks.test.ts
+++ b/src/services/__tests__/sync-hooks.test.ts
@@ -8,10 +8,18 @@
  * The real sync service and hooks run.
  */
 
-import { act, renderHook } from "@testing-library/react-native";
+import { act, renderHook, waitFor } from "@testing-library/react-native";
 
-import { usePullToRefresh } from "@/services/sync-service";
+import { useForegroundSync, usePullToRefresh } from "@/services/sync-service";
+import {
+  resetForTesting as resetDataVersionStore,
+  useDataVersion,
+} from "@/stores/data-version";
 import { useDevice } from "@/stores/device";
+import {
+  resetForTesting as resetSessionStore,
+  useSession,
+} from "@/stores/session";
 import { setupTestDatabase } from "@test/db-test-utils";
 import { DEFAULT_TEST_SESSION } from "@test/factories";
 import {
@@ -125,5 +133,63 @@ describe("usePullToRefresh", () => {
 
     // Should be false after successful sync
     expect(result.current.refreshing).toBe(false);
+  });
+});
+
+describe("useForegroundSync", () => {
+  let mockFetch: ReturnType<typeof installFetchMock>;
+
+  beforeEach(() => {
+    mockFetch = installFetchMock();
+    resetSessionStore();
+    resetDataVersionStore();
+
+    useSession.setState({ session: DEFAULT_TEST_SESSION });
+    useDevice.setState({
+      initialized: true,
+      deviceInfo: {
+        id: "test-device-id",
+        type: "android",
+        brand: "TestBrand",
+        modelName: "TestModel",
+        osName: "Android",
+        osVersion: "14",
+        appId: "app.ambry.mobile.dev",
+        appVersion: "1.0.0",
+        appBuild: "1",
+      },
+    });
+  });
+
+  afterEach(() => {
+    resetSessionStore();
+    resetDataVersionStore();
+  });
+
+  it("syncs immediately when the app is active", async () => {
+    const serverTime = "2024-01-15T10:00:00.000Z";
+
+    mockGraphQL(mockFetch, graphqlSuccess(emptyLibraryChanges(serverTime)));
+    mockGraphQL(mockFetch, graphqlSuccess(emptySyncEventsResult(serverTime)));
+
+    const { unmount } = renderHook(() => useForegroundSync("active"));
+
+    // The sync runs right away, not only after the 15-minute interval
+    await waitFor(() => {
+      expect(useDataVersion.getState().libraryDataVersion).toBe(
+        new Date(serverTime).getTime(),
+      );
+    });
+
+    unmount();
+  });
+
+  it("does not sync while the app is in the background", async () => {
+    const { unmount } = renderHook(() => useForegroundSync("background"));
+
+    await act(async () => {});
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    unmount();
   });
 });

--- a/src/services/__tests__/sync-service.test.ts
+++ b/src/services/__tests__/sync-service.test.ts
@@ -24,6 +24,7 @@ import {
 import { setupTestDatabase } from "@test/db-test-utils";
 import { DEFAULT_TEST_SESSION } from "@test/factories";
 import {
+  getGraphQLVariables,
   graphqlSuccess,
   graphqlUnauthorized,
   installFetchMock,
@@ -128,6 +129,40 @@ describe("sync-service", () => {
       // Session should be cleared
       const { session: currentSession } = useSession.getState();
       expect(currentSession).toBeNull();
+    });
+
+    it("re-fetches the entire library when fullResync is set", async () => {
+      const firstServerTime = "2024-01-15T10:00:00.000Z";
+      const secondServerTime = "2024-01-16T10:00:00.000Z";
+      const thirdServerTime = "2024-01-17T10:00:00.000Z";
+
+      // First sync stores the cursor
+      mockGraphQL(
+        mockFetch,
+        graphqlSuccess(emptyLibraryChanges(firstServerTime)),
+      );
+      await syncLibrary(session);
+
+      // A normal second sync sends the stored cursor
+      mockGraphQL(
+        mockFetch,
+        graphqlSuccess(emptyLibraryChanges(secondServerTime)),
+      );
+      await syncLibrary(session);
+      expect(getGraphQLVariables(mockFetch, 1)?.since).toBe(firstServerTime);
+
+      // A full resync ignores the stored cursor and asks for everything
+      mockGraphQL(
+        mockFetch,
+        graphqlSuccess(emptyLibraryChanges(thirdServerTime)),
+      );
+      await syncLibrary(session, { fullResync: true });
+      expect(getGraphQLVariables(mockFetch, 2)?.since).toBeNull();
+
+      // The data version advances to the new server time even with no changes
+      expect(useDataVersion.getState().libraryDataVersion).toBe(
+        new Date(thirdServerTime).getTime(),
+      );
     });
   });
 

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -10,6 +10,8 @@ import {
   CreateSessionError,
   deleteSession,
 } from "@/graphql/api";
+import { reset as resetDataVersion } from "@/stores/data-version";
+import { reset as resetDownloads } from "@/stores/downloads";
 import { useSession } from "@/stores/session";
 import { Result } from "@/types/result";
 
@@ -47,5 +49,11 @@ export async function signOut() {
   if (session) {
     await deleteSession(session.url, session.token);
     useSession.setState({ session: null });
+
+    // The JS context can outlive a sign-out (the player's foreground service
+    // keeps it alive), so session-scoped stores must not stay initialized —
+    // otherwise the next sign-in skips re-initialization and the initial sync.
+    resetDataVersion();
+    resetDownloads();
   }
 }

--- a/src/services/library-service.ts
+++ b/src/services/library-service.ts
@@ -173,11 +173,13 @@ export function usePaginatedLibraryData<T, Cursor>(
     setLoading(false);
   }, [getPage, getCursor, cursor, loading, hasMore, pageSize]);
 
-  // Reload all currently loaded items
+  // Reload all currently loaded items, but always at least one page — a
+  // screen that is currently empty must be able to pick up rows that a sync
+  // just inserted.
   const reload = useCallback(async () => {
     setLoading(true);
 
-    const count = items?.length || 0;
+    const count = Math.max(items?.length || 0, pageSize);
     let all: T[] = [];
     let nextCursor: Cursor | undefined = undefined;
     let fetched = 0;

--- a/src/services/sync-service.ts
+++ b/src/services/sync-service.ts
@@ -58,11 +58,28 @@ function logGQLError(error: ExecuteAuthenticatedError, context: string) {
 // Library Sync
 // =============================================================================
 
-export async function syncLibrary(session: Session): Promise<void> {
-  log.debug("Syncing library");
+interface SyncLibraryOptions {
+  fullResync?: boolean;
+}
 
-  // 1. Get last sync info from DB
-  const syncInfo = await getLastLibrarySyncInfo(session);
+export async function syncLibrary(
+  session: Session,
+  options: SyncLibraryOptions = {},
+): Promise<void> {
+  const { fullResync = false } = options;
+
+  if (fullResync) {
+    log.info("Performing full library resync");
+  } else {
+    log.debug("Syncing library");
+  }
+
+  // 1. Get last sync info from DB; a full resync discards the stored cursor
+  // so the server sends the entire library again
+  const storedSyncInfo = await getLastLibrarySyncInfo(session);
+  const syncInfo = fullResync
+    ? { ...storedSyncInfo, lastSyncTime: null }
+    : storedSyncInfo;
 
   // 2. Call GraphQL API to get changes
   const result = await getLibraryChangesSince(session, syncInfo.lastSyncTime);
@@ -211,12 +228,13 @@ export async function syncPlaybackEvents(
 
 interface SyncOptions {
   fullEventResync?: boolean;
+  fullLibraryResync?: boolean;
 }
 
 export async function sync(session: Session, options: SyncOptions = {}) {
-  const { fullEventResync = false } = options;
+  const { fullEventResync = false, fullLibraryResync = false } = options;
   return Promise.all([
-    syncLibrary(session),
+    syncLibrary(session, { fullResync: fullLibraryResync }),
     syncPlaybackEvents(session, { fullResync: fullEventResync }),
   ]);
 }
@@ -226,7 +244,8 @@ export async function sync(session: Session, options: SyncOptions = {}) {
 // =============================================================================
 
 /**
- * Periodic sync every 15 minutes while the app is in the foreground.
+ * Syncs immediately whenever the app becomes active, then every 15 minutes
+ * while it stays in the foreground.
  */
 export function useForegroundSync(appState: AppStateStatus) {
   const session = useSession((state) => state.session);
@@ -253,7 +272,8 @@ export function useForegroundSync(appState: AppStateStatus) {
     };
 
     if (session && appState === "active") {
-      log.debug("ForegroundSync: starting periodic sync");
+      log.debug("ForegroundSync: syncing now and starting periodic sync");
+      performSync();
       intervalId = setInterval(performSync, FOREGROUND_SYNC_INTERVAL);
     }
 

--- a/src/stores/data-version.ts
+++ b/src/stores/data-version.ts
@@ -46,8 +46,16 @@ export function bumpShelfDataVersion() {
 }
 
 /**
+ * Reset store to initial state. Called on sign-out so the next sign-in
+ * re-initializes from the database and performs an initial sync.
+ */
+export function reset() {
+  useDataVersion.setState(initialDataVersionState, true);
+}
+
+/**
  * Reset store to initial state for testing.
  */
 export function resetForTesting() {
-  useDataVersion.setState(initialDataVersionState, true);
+  reset();
 }

--- a/src/stores/downloads.ts
+++ b/src/stores/downloads.ts
@@ -43,8 +43,16 @@ export function removeDownloadFromStore(mediaId: string) {
 }
 
 /**
+ * Reset store to initial state. Called on sign-out so the next sign-in
+ * re-initializes from the database for the new session.
+ */
+export function reset() {
+  useDownloads.setState(initialDownloadsState, true);
+}
+
+/**
  * Reset store to initial state for testing.
  */
 export function resetForTesting() {
-  useDownloads.setState(initialDownloadsState, true);
+  reset();
 }


### PR DESCRIPTION
Fixes three related sync bugs observed on a fresh login to a new server:

1. **A fresh login didn't perform an initial sync.** The player's foreground service keeps the JS context alive across sign-out, so the data-version store's `initialized` flag survived into the next sign-in. `initializeDataVersion()` then short-circuited and reported `needsInitialSync: false`, and boot skipped the initial sync entirely — the library stayed empty. Sign-out now resets the data-version and downloads stores. Relatedly, the foreground sync hook only ever *started* a 15-minute interval, so opening the app after time away didn't sync until 15 minutes later; it now syncs immediately when the app becomes active.

2. **No pull-to-refresh on the empty library screen.** The empty state was a plain `View` with no scrollable surface. It's now a scroll view with a `RefreshControl` wired to the same sync as the populated list.

3. **Force Full Sync appeared to do nothing.** Three compounding issues:
   - `usePaginatedLibraryData`'s `reload()` refetched `items.length` items — zero for a screen currently showing an empty list — so even a successful sync couldn't make items appear until the screen remounted. It now reloads at least one page. This affected every screen using the hook.
   - It only forced a full *event* resync; the library half was always incremental. It now also clears the library sync cursor and re-fetches the full library.
   - The Android row gave no feedback at all. It now has a ripple, shows a spinner and "Syncing…" while running, is disabled during the sync, and shows a completion/failure toast (matching the completion alert iOS already had).

## Tests

- `syncLibrary` full-resync sends `since: null` despite a stored cursor and advances the library data version
- `useForegroundSync` syncs immediately when active and not while backgrounded
- `signOut` clears the session and resets the session-scoped stores
- `usePaginatedLibraryData` picks up rows inserted by a sync when the list was empty (regression) and reloads loaded items on version bumps

`npx tsc`, `npm run lint`, and `npm test` (65 suites, 670 tests) all pass.

## Stores intentionally not reset on sign-out

The sleep-timer and preferred-playback-rate stores keep their `initialized` flags across sign-out, but `localUserSettings` is keyed by email only (not server URL), so signing into a different server as the same user picks up identical values. Only signing in as a *different email* in the same JS context briefly inherits the previous account's in-memory preferences until a setting is changed; writes always go to the correct email, so nothing is persisted wrongly.