### PR TITLE
Make playback and sleep timer preferences device-scoped

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ State is split across three stores by responsibility:
 - **Library tables**: `people`, `authors`, `narrators`, `books`, `media`, `series` (synced from server)
 - **Playback progress**: `playthroughs` (listening sessions), `playbackEvents` (event-sourced history)
 - **Downloads**: `downloads` (local file paths, resumable state)
-- **User data**: `localUserSettings`, `shelvedMedia`
+- **User data**: `localSettings` (device-scoped playback/sleep-timer preferences, single row), `shelvedMedia`
 - **Sync metadata**: `syncedServers`, `serverProfiles` (timestamps for incremental sync)
 
 **Event-Sourced Playback Progress**:

--- a/drizzle/0023_amused_rhino.sql
+++ b/drizzle/0023_amused_rhino.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `local_settings` (
+	`id` text PRIMARY KEY DEFAULT 'local' NOT NULL,
+	`preferred_playback_rate` real DEFAULT 1 NOT NULL,
+	`sleep_timer` integer DEFAULT 600 NOT NULL,
+	`sleep_timer_enabled` integer DEFAULT false NOT NULL,
+	`sleep_timer_motion_detection_enabled` integer DEFAULT false NOT NULL,
+	`sleep_timer_trigger_time` integer
+);
+--> statement-breakpoint
+INSERT INTO `local_settings` (`id`, `preferred_playback_rate`, `sleep_timer`, `sleep_timer_enabled`, `sleep_timer_motion_detection_enabled`, `sleep_timer_trigger_time`)
+SELECT 'local', s.`preferred_playback_rate`, s.`sleep_timer`, s.`sleep_timer_enabled`, s.`sleep_timer_motion_detection_enabled`, s.`sleep_timer_trigger_time`
+FROM `local_user_settings` s
+ORDER BY (
+	SELECT max(p.`last_sync_time`)
+	FROM `server_profiles` p
+	WHERE p.`user_email` = s.`user_email`
+) DESC, s.`rowid` DESC
+LIMIT 1;
+--> statement-breakpoint
+DROP TABLE `local_user_settings`;

--- a/drizzle/0024_watery_madelyne_pryor.sql
+++ b/drizzle/0024_watery_madelyne_pryor.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `local_settings` DROP COLUMN `sleep_timer_trigger_time`;

--- a/drizzle/meta/0023_snapshot.json
+++ b/drizzle/meta/0023_snapshot.json
@@ -1,0 +1,1782 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "bac9fa83-25cd-484e-a856-ca83beaf2b6f",
+  "prevId": "d15a72bf-96b9-41a0-aa17-5ddc156a4453",
+  "tables": {
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_person_index": {
+          "name": "authors_person_index",
+          "columns": [
+            "url",
+            "person_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "authors_url_person_id_people_url_id_fk": {
+          "name": "authors_url_person_id_people_url_id_fk",
+          "tableFrom": "authors",
+          "tableTo": "people",
+          "columnsFrom": [
+            "url",
+            "person_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "authors_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "authors_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "book_authors": {
+      "name": "book_authors",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "book_authors_author_index": {
+          "name": "book_authors_author_index",
+          "columns": [
+            "url",
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "book_authors_book_index": {
+          "name": "book_authors_book_index",
+          "columns": [
+            "url",
+            "book_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "book_authors_url_author_id_authors_url_id_fk": {
+          "name": "book_authors_url_author_id_authors_url_id_fk",
+          "tableFrom": "book_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "url",
+            "author_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_authors_url_book_id_books_url_id_fk": {
+          "name": "book_authors_url_book_id_books_url_id_fk",
+          "tableFrom": "book_authors",
+          "tableTo": "books",
+          "columnsFrom": [
+            "url",
+            "book_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_authors_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "book_authors_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "books": {
+      "name": "books",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_format": {
+          "name": "published_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "books_published_index": {
+          "name": "books_published_index",
+          "columns": [
+            "published"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "books_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "books_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "downloads": {
+      "name": "downloads",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "downloaded_at": {
+          "name": "downloaded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumbnails": {
+          "name": "thumbnails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_resumable_snapshot": {
+          "name": "download_resumable_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "downloads_media_index": {
+          "name": "downloads_media_index",
+          "columns": [
+            "url",
+            "media_id"
+          ],
+          "isUnique": false
+        },
+        "downloads_downloaded_at_index": {
+          "name": "downloads_downloaded_at_index",
+          "columns": [
+            "downloaded_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "downloads_url_media_id_media_url_id_fk": {
+          "name": "downloads_url_media_id_media_url_id_fk",
+          "tableFrom": "downloads",
+          "tableTo": "media",
+          "columnsFrom": [
+            "url",
+            "media_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "downloads_url_media_id_pk": {
+          "columns": [
+            "url",
+            "media_id"
+          ],
+          "name": "downloads_url_media_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "local_player_states": {
+      "name": "local_player_states",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playback_rate": {
+          "name": "playback_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "local_player_states_media_index": {
+          "name": "local_player_states_media_index",
+          "columns": [
+            "url",
+            "media_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "local_player_states_url_media_id_media_url_id_fk": {
+          "name": "local_player_states_url_media_id_media_url_id_fk",
+          "tableFrom": "local_player_states",
+          "tableTo": "media",
+          "columnsFrom": [
+            "url",
+            "media_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "local_player_states_url_media_id_user_email_pk": {
+          "columns": [
+            "url",
+            "media_id",
+            "user_email"
+          ],
+          "name": "local_player_states_url_media_id_user_email_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "local_settings": {
+      "name": "local_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "preferred_playback_rate": {
+          "name": "preferred_playback_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sleep_timer": {
+          "name": "sleep_timer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 600
+        },
+        "sleep_timer_enabled": {
+          "name": "sleep_timer_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sleep_timer_motion_detection_enabled": {
+          "name": "sleep_timer_motion_detection_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sleep_timer_trigger_time": {
+          "name": "sleep_timer_trigger_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chapters": {
+          "name": "chapters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplemental_files": {
+          "name": "supplemental_files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_cast": {
+          "name": "full_cast",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "abridged": {
+          "name": "abridged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mpd_path": {
+          "name": "mpd_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hls_path": {
+          "name": "hls_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mp4_path": {
+          "name": "mp4_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_format": {
+          "name": "published_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnails": {
+          "name": "thumbnails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_book_index": {
+          "name": "media_book_index",
+          "columns": [
+            "url",
+            "book_id"
+          ],
+          "isUnique": false
+        },
+        "media_status_index": {
+          "name": "media_status_index",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "media_inserted_at_index": {
+          "name": "media_inserted_at_index",
+          "columns": [
+            "inserted_at"
+          ],
+          "isUnique": false
+        },
+        "media_published_index": {
+          "name": "media_published_index",
+          "columns": [
+            "published"
+          ],
+          "isUnique": false
+        },
+        "media_url_status_inserted_at_idx": {
+          "name": "media_url_status_inserted_at_idx",
+          "columns": [
+            "url",
+            "status",
+            "inserted_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_url_book_id_books_url_id_fk": {
+          "name": "media_url_book_id_books_url_id_fk",
+          "tableFrom": "media",
+          "tableTo": "books",
+          "columnsFrom": [
+            "url",
+            "book_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "media_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_narrators": {
+      "name": "media_narrators",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "narrator_id": {
+          "name": "narrator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_narrators_media_index": {
+          "name": "media_narrators_media_index",
+          "columns": [
+            "url",
+            "media_id"
+          ],
+          "isUnique": false
+        },
+        "media_narrators_narrator_index": {
+          "name": "media_narrators_narrator_index",
+          "columns": [
+            "url",
+            "narrator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_narrators_url_media_id_media_url_id_fk": {
+          "name": "media_narrators_url_media_id_media_url_id_fk",
+          "tableFrom": "media_narrators",
+          "tableTo": "media",
+          "columnsFrom": [
+            "url",
+            "media_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_narrators_url_narrator_id_narrators_url_id_fk": {
+          "name": "media_narrators_url_narrator_id_narrators_url_id_fk",
+          "tableFrom": "media_narrators",
+          "tableTo": "narrators",
+          "columnsFrom": [
+            "url",
+            "narrator_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_narrators_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "media_narrators_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "narrators": {
+      "name": "narrators",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "narrators_person_index": {
+          "name": "narrators_person_index",
+          "columns": [
+            "url",
+            "person_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "narrators_url_person_id_people_url_id_fk": {
+          "name": "narrators_url_person_id_people_url_id_fk",
+          "tableFrom": "narrators",
+          "tableTo": "people",
+          "columnsFrom": [
+            "url",
+            "person_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "narrators_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "narrators_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnails": {
+          "name": "thumbnails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "people_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "people_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playback_events": {
+      "name": "playback_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playthrough_id": {
+          "name": "playthrough_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "playback_rate": {
+          "name": "playback_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_position": {
+          "name": "from_position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_position": {
+          "name": "to_position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_rate": {
+          "name": "previous_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "playback_events_playthrough_timestamp_idx": {
+          "name": "playback_events_playthrough_timestamp_idx",
+          "columns": [
+            "playthrough_id",
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "playback_events_synced_at_idx": {
+          "name": "playback_events_synced_at_idx",
+          "columns": [
+            "synced_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_states": {
+      "name": "player_states",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playback_rate": {
+          "name": "playback_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "player_states_email_index": {
+          "name": "player_states_email_index",
+          "columns": [
+            "user_email"
+          ],
+          "isUnique": false
+        },
+        "player_states_status_index": {
+          "name": "player_states_status_index",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "player_states_media_index": {
+          "name": "player_states_media_index",
+          "columns": [
+            "url",
+            "media_id"
+          ],
+          "isUnique": false
+        },
+        "player_states_updated_at_index": {
+          "name": "player_states_updated_at_index",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_states_url_media_id_media_url_id_fk": {
+          "name": "player_states_url_media_id_media_url_id_fk",
+          "tableFrom": "player_states",
+          "tableTo": "media",
+          "columnsFrom": [
+            "url",
+            "media_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_states_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "player_states_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playthrough_state_cache": {
+      "name": "playthrough_state_cache",
+      "columns": {
+        "playthrough_id": {
+          "name": "playthrough_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playthroughs": {
+      "name": "playthroughs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "abandoned_at": {
+          "name": "abandoned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playback_rate": {
+          "name": "playback_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refreshed_at": {
+          "name": "refreshed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "playthroughs_user_media_idx": {
+          "name": "playthroughs_user_media_idx",
+          "columns": [
+            "url",
+            "user_email",
+            "media_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "playthroughs_url_media_id_media_url_id_fk": {
+          "name": "playthroughs_url_media_id_media_url_id_fk",
+          "tableFrom": "playthroughs",
+          "tableTo": "media",
+          "columnsFrom": [
+            "url",
+            "media_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "playthroughs_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "playthroughs_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "series": {
+      "name": "series",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "series_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "series_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "series_books": {
+      "name": "series_books",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "book_number": {
+          "name": "book_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "series_books_book_index": {
+          "name": "series_books_book_index",
+          "columns": [
+            "url",
+            "book_id"
+          ],
+          "isUnique": false
+        },
+        "series_books_series_index": {
+          "name": "series_books_series_index",
+          "columns": [
+            "url",
+            "series_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "series_books_url_book_id_books_url_id_fk": {
+          "name": "series_books_url_book_id_books_url_id_fk",
+          "tableFrom": "series_books",
+          "tableTo": "books",
+          "columnsFrom": [
+            "url",
+            "book_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "series_books_url_series_id_series_url_id_fk": {
+          "name": "series_books_url_series_id_series_url_id_fk",
+          "tableFrom": "series_books",
+          "tableTo": "series",
+          "columnsFrom": [
+            "url",
+            "series_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "series_books_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "series_books_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "server_profiles": {
+      "name": "server_profiles",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_sync_time": {
+          "name": "last_sync_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_full_playthrough_sync_time": {
+          "name": "last_full_playthrough_sync_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_playthrough_id": {
+          "name": "active_playthrough_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "server_profiles_url_user_email_pk": {
+          "columns": [
+            "url",
+            "user_email"
+          ],
+          "name": "server_profiles_url_user_email_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shelved_media": {
+      "name": "shelved_media",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shelf_name": {
+          "name": "shelf_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "shelved_media_shelf_name_index": {
+          "name": "shelved_media_shelf_name_index",
+          "columns": [
+            "url",
+            "user_email",
+            "shelf_name"
+          ],
+          "isUnique": false
+        },
+        "shelved_media_synced_index": {
+          "name": "shelved_media_synced_index",
+          "columns": [
+            "url",
+            "user_email",
+            "synced"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "shelved_media_url_media_id_media_url_id_fk": {
+          "name": "shelved_media_url_media_id_media_url_id_fk",
+          "tableFrom": "shelved_media",
+          "tableTo": "media",
+          "columnsFrom": [
+            "url",
+            "media_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "shelved_media_url_user_email_shelf_name_media_id_pk": {
+          "columns": [
+            "url",
+            "user_email",
+            "shelf_name",
+            "media_id"
+          ],
+          "name": "shelved_media_url_user_email_shelf_name_media_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "synced_servers": {
+      "name": "synced_servers",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_sync_time": {
+          "name": "last_sync_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "library_data_version": {
+          "name": "library_data_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,1775 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "eefd10f6-2159-4bd2-9cf9-3dbbede02f46",
+  "prevId": "bac9fa83-25cd-484e-a856-ca83beaf2b6f",
+  "tables": {
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_person_index": {
+          "name": "authors_person_index",
+          "columns": [
+            "url",
+            "person_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "authors_url_person_id_people_url_id_fk": {
+          "name": "authors_url_person_id_people_url_id_fk",
+          "tableFrom": "authors",
+          "tableTo": "people",
+          "columnsFrom": [
+            "url",
+            "person_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "authors_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "authors_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "book_authors": {
+      "name": "book_authors",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "book_authors_author_index": {
+          "name": "book_authors_author_index",
+          "columns": [
+            "url",
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "book_authors_book_index": {
+          "name": "book_authors_book_index",
+          "columns": [
+            "url",
+            "book_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "book_authors_url_author_id_authors_url_id_fk": {
+          "name": "book_authors_url_author_id_authors_url_id_fk",
+          "tableFrom": "book_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "url",
+            "author_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_authors_url_book_id_books_url_id_fk": {
+          "name": "book_authors_url_book_id_books_url_id_fk",
+          "tableFrom": "book_authors",
+          "tableTo": "books",
+          "columnsFrom": [
+            "url",
+            "book_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_authors_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "book_authors_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "books": {
+      "name": "books",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_format": {
+          "name": "published_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "books_published_index": {
+          "name": "books_published_index",
+          "columns": [
+            "published"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "books_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "books_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "downloads": {
+      "name": "downloads",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "downloaded_at": {
+          "name": "downloaded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumbnails": {
+          "name": "thumbnails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_resumable_snapshot": {
+          "name": "download_resumable_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "downloads_media_index": {
+          "name": "downloads_media_index",
+          "columns": [
+            "url",
+            "media_id"
+          ],
+          "isUnique": false
+        },
+        "downloads_downloaded_at_index": {
+          "name": "downloads_downloaded_at_index",
+          "columns": [
+            "downloaded_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "downloads_url_media_id_media_url_id_fk": {
+          "name": "downloads_url_media_id_media_url_id_fk",
+          "tableFrom": "downloads",
+          "tableTo": "media",
+          "columnsFrom": [
+            "url",
+            "media_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "downloads_url_media_id_pk": {
+          "columns": [
+            "url",
+            "media_id"
+          ],
+          "name": "downloads_url_media_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "local_player_states": {
+      "name": "local_player_states",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playback_rate": {
+          "name": "playback_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "local_player_states_media_index": {
+          "name": "local_player_states_media_index",
+          "columns": [
+            "url",
+            "media_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "local_player_states_url_media_id_media_url_id_fk": {
+          "name": "local_player_states_url_media_id_media_url_id_fk",
+          "tableFrom": "local_player_states",
+          "tableTo": "media",
+          "columnsFrom": [
+            "url",
+            "media_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "local_player_states_url_media_id_user_email_pk": {
+          "columns": [
+            "url",
+            "media_id",
+            "user_email"
+          ],
+          "name": "local_player_states_url_media_id_user_email_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "local_settings": {
+      "name": "local_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "preferred_playback_rate": {
+          "name": "preferred_playback_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sleep_timer": {
+          "name": "sleep_timer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 600
+        },
+        "sleep_timer_enabled": {
+          "name": "sleep_timer_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sleep_timer_motion_detection_enabled": {
+          "name": "sleep_timer_motion_detection_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chapters": {
+          "name": "chapters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplemental_files": {
+          "name": "supplemental_files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_cast": {
+          "name": "full_cast",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "abridged": {
+          "name": "abridged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mpd_path": {
+          "name": "mpd_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hls_path": {
+          "name": "hls_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mp4_path": {
+          "name": "mp4_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_format": {
+          "name": "published_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnails": {
+          "name": "thumbnails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_book_index": {
+          "name": "media_book_index",
+          "columns": [
+            "url",
+            "book_id"
+          ],
+          "isUnique": false
+        },
+        "media_status_index": {
+          "name": "media_status_index",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "media_inserted_at_index": {
+          "name": "media_inserted_at_index",
+          "columns": [
+            "inserted_at"
+          ],
+          "isUnique": false
+        },
+        "media_published_index": {
+          "name": "media_published_index",
+          "columns": [
+            "published"
+          ],
+          "isUnique": false
+        },
+        "media_url_status_inserted_at_idx": {
+          "name": "media_url_status_inserted_at_idx",
+          "columns": [
+            "url",
+            "status",
+            "inserted_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_url_book_id_books_url_id_fk": {
+          "name": "media_url_book_id_books_url_id_fk",
+          "tableFrom": "media",
+          "tableTo": "books",
+          "columnsFrom": [
+            "url",
+            "book_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "media_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_narrators": {
+      "name": "media_narrators",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "narrator_id": {
+          "name": "narrator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_narrators_media_index": {
+          "name": "media_narrators_media_index",
+          "columns": [
+            "url",
+            "media_id"
+          ],
+          "isUnique": false
+        },
+        "media_narrators_narrator_index": {
+          "name": "media_narrators_narrator_index",
+          "columns": [
+            "url",
+            "narrator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_narrators_url_media_id_media_url_id_fk": {
+          "name": "media_narrators_url_media_id_media_url_id_fk",
+          "tableFrom": "media_narrators",
+          "tableTo": "media",
+          "columnsFrom": [
+            "url",
+            "media_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_narrators_url_narrator_id_narrators_url_id_fk": {
+          "name": "media_narrators_url_narrator_id_narrators_url_id_fk",
+          "tableFrom": "media_narrators",
+          "tableTo": "narrators",
+          "columnsFrom": [
+            "url",
+            "narrator_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_narrators_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "media_narrators_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "narrators": {
+      "name": "narrators",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "narrators_person_index": {
+          "name": "narrators_person_index",
+          "columns": [
+            "url",
+            "person_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "narrators_url_person_id_people_url_id_fk": {
+          "name": "narrators_url_person_id_people_url_id_fk",
+          "tableFrom": "narrators",
+          "tableTo": "people",
+          "columnsFrom": [
+            "url",
+            "person_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "narrators_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "narrators_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnails": {
+          "name": "thumbnails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "people_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "people_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playback_events": {
+      "name": "playback_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playthrough_id": {
+          "name": "playthrough_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "playback_rate": {
+          "name": "playback_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_position": {
+          "name": "from_position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_position": {
+          "name": "to_position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_rate": {
+          "name": "previous_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "playback_events_playthrough_timestamp_idx": {
+          "name": "playback_events_playthrough_timestamp_idx",
+          "columns": [
+            "playthrough_id",
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "playback_events_synced_at_idx": {
+          "name": "playback_events_synced_at_idx",
+          "columns": [
+            "synced_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_states": {
+      "name": "player_states",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playback_rate": {
+          "name": "playback_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "player_states_email_index": {
+          "name": "player_states_email_index",
+          "columns": [
+            "user_email"
+          ],
+          "isUnique": false
+        },
+        "player_states_status_index": {
+          "name": "player_states_status_index",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "player_states_media_index": {
+          "name": "player_states_media_index",
+          "columns": [
+            "url",
+            "media_id"
+          ],
+          "isUnique": false
+        },
+        "player_states_updated_at_index": {
+          "name": "player_states_updated_at_index",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_states_url_media_id_media_url_id_fk": {
+          "name": "player_states_url_media_id_media_url_id_fk",
+          "tableFrom": "player_states",
+          "tableTo": "media",
+          "columnsFrom": [
+            "url",
+            "media_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_states_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "player_states_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playthrough_state_cache": {
+      "name": "playthrough_state_cache",
+      "columns": {
+        "playthrough_id": {
+          "name": "playthrough_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playthroughs": {
+      "name": "playthroughs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "abandoned_at": {
+          "name": "abandoned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playback_rate": {
+          "name": "playback_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refreshed_at": {
+          "name": "refreshed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "playthroughs_user_media_idx": {
+          "name": "playthroughs_user_media_idx",
+          "columns": [
+            "url",
+            "user_email",
+            "media_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "playthroughs_url_media_id_media_url_id_fk": {
+          "name": "playthroughs_url_media_id_media_url_id_fk",
+          "tableFrom": "playthroughs",
+          "tableTo": "media",
+          "columnsFrom": [
+            "url",
+            "media_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "playthroughs_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "playthroughs_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "series": {
+      "name": "series",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "series_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "series_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "series_books": {
+      "name": "series_books",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "book_number": {
+          "name": "book_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "series_books_book_index": {
+          "name": "series_books_book_index",
+          "columns": [
+            "url",
+            "book_id"
+          ],
+          "isUnique": false
+        },
+        "series_books_series_index": {
+          "name": "series_books_series_index",
+          "columns": [
+            "url",
+            "series_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "series_books_url_book_id_books_url_id_fk": {
+          "name": "series_books_url_book_id_books_url_id_fk",
+          "tableFrom": "series_books",
+          "tableTo": "books",
+          "columnsFrom": [
+            "url",
+            "book_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "series_books_url_series_id_series_url_id_fk": {
+          "name": "series_books_url_series_id_series_url_id_fk",
+          "tableFrom": "series_books",
+          "tableTo": "series",
+          "columnsFrom": [
+            "url",
+            "series_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "series_books_url_id_pk": {
+          "columns": [
+            "url",
+            "id"
+          ],
+          "name": "series_books_url_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "server_profiles": {
+      "name": "server_profiles",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_sync_time": {
+          "name": "last_sync_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_full_playthrough_sync_time": {
+          "name": "last_full_playthrough_sync_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_playthrough_id": {
+          "name": "active_playthrough_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "server_profiles_url_user_email_pk": {
+          "columns": [
+            "url",
+            "user_email"
+          ],
+          "name": "server_profiles_url_user_email_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shelved_media": {
+      "name": "shelved_media",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shelf_name": {
+          "name": "shelf_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "shelved_media_shelf_name_index": {
+          "name": "shelved_media_shelf_name_index",
+          "columns": [
+            "url",
+            "user_email",
+            "shelf_name"
+          ],
+          "isUnique": false
+        },
+        "shelved_media_synced_index": {
+          "name": "shelved_media_synced_index",
+          "columns": [
+            "url",
+            "user_email",
+            "synced"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "shelved_media_url_media_id_media_url_id_fk": {
+          "name": "shelved_media_url_media_id_media_url_id_fk",
+          "tableFrom": "shelved_media",
+          "tableTo": "media",
+          "columnsFrom": [
+            "url",
+            "media_id"
+          ],
+          "columnsTo": [
+            "url",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "shelved_media_url_user_email_shelf_name_media_id_pk": {
+          "columns": [
+            "url",
+            "user_email",
+            "shelf_name",
+            "media_id"
+          ],
+          "name": "shelved_media_url_user_email_shelf_name_media_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "synced_servers": {
+      "name": "synced_servers",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_sync_time": {
+          "name": "last_sync_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "library_data_version": {
+          "name": "library_data_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1768768337279,
       "tag": "0022_graceful_elektra",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "6",
+      "when": 1785608727850,
+      "tag": "0023_amused_rhino",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1785608727850,
       "tag": "0023_amused_rhino",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "6",
+      "when": 1785610364053,
+      "tag": "0024_watery_madelyne_pryor",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -1,55 +1,58 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
-import journal from "./meta/_journal.json";
-import m0000 from "./0000_secret_tomorrow_man.sql";
-import m0001 from "./0001_loud_madame_web.sql";
-import m0002 from "./0002_productive_newton_destine.sql";
-import m0003 from "./0003_overjoyed_typhoid_mary.sql";
-import m0004 from "./0004_tricky_leo.sql";
-import m0005 from "./0005_green_moondragon.sql";
-import m0006 from "./0006_aromatic_eternals.sql";
-import m0007 from "./0007_numerous_wong.sql";
-import m0008 from "./0008_hard_raider.sql";
-import m0009 from "./0009_aberrant_sprite.sql";
-import m0010 from "./0010_spotty_black_bird.sql";
-import m0011 from "./0011_stiff_james_howlett.sql";
-import m0012 from "./0012_complex_bulldozer.sql";
-import m0013 from "./0013_big_kronos.sql";
-import m0014 from "./0014_overrated_carmella_unuscione.sql";
-import m0015 from "./0015_absent_silverclaw.sql";
-import m0016 from "./0016_absent_mister_sinister.sql";
-import m0017 from "./0017_supreme_silk_fever.sql";
-import m0018 from "./0018_cultured_fantastic_four.sql";
-import m0019 from "./0019_dry_micromacro.sql";
-import m0020 from "./0020_smiling_betty_brant.sql";
-import m0021 from "./0021_violet_reavers.sql";
-import m0022 from "./0022_graceful_elektra.sql";
+import journal from './meta/_journal.json';
+import m0000 from './0000_secret_tomorrow_man.sql';
+import m0001 from './0001_loud_madame_web.sql';
+import m0002 from './0002_productive_newton_destine.sql';
+import m0003 from './0003_overjoyed_typhoid_mary.sql';
+import m0004 from './0004_tricky_leo.sql';
+import m0005 from './0005_green_moondragon.sql';
+import m0006 from './0006_aromatic_eternals.sql';
+import m0007 from './0007_numerous_wong.sql';
+import m0008 from './0008_hard_raider.sql';
+import m0009 from './0009_aberrant_sprite.sql';
+import m0010 from './0010_spotty_black_bird.sql';
+import m0011 from './0011_stiff_james_howlett.sql';
+import m0012 from './0012_complex_bulldozer.sql';
+import m0013 from './0013_big_kronos.sql';
+import m0014 from './0014_overrated_carmella_unuscione.sql';
+import m0015 from './0015_absent_silverclaw.sql';
+import m0016 from './0016_absent_mister_sinister.sql';
+import m0017 from './0017_supreme_silk_fever.sql';
+import m0018 from './0018_cultured_fantastic_four.sql';
+import m0019 from './0019_dry_micromacro.sql';
+import m0020 from './0020_smiling_betty_brant.sql';
+import m0021 from './0021_violet_reavers.sql';
+import m0022 from './0022_graceful_elektra.sql';
+import m0023 from './0023_amused_rhino.sql';
 
-export default {
-  journal,
-  migrations: {
-    m0000,
-    m0001,
-    m0002,
-    m0003,
-    m0004,
-    m0005,
-    m0006,
-    m0007,
-    m0008,
-    m0009,
-    m0010,
-    m0011,
-    m0012,
-    m0013,
-    m0014,
-    m0015,
-    m0016,
-    m0017,
-    m0018,
-    m0019,
-    m0020,
-    m0021,
-    m0022,
-  },
-};
+  export default {
+    journal,
+    migrations: {
+      m0000,
+m0001,
+m0002,
+m0003,
+m0004,
+m0005,
+m0006,
+m0007,
+m0008,
+m0009,
+m0010,
+m0011,
+m0012,
+m0013,
+m0014,
+m0015,
+m0016,
+m0017,
+m0018,
+m0019,
+m0020,
+m0021,
+m0022,
+m0023
+    }
+  }
+  

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -25,6 +25,7 @@ import m0020 from './0020_smiling_betty_brant.sql';
 import m0021 from './0021_violet_reavers.sql';
 import m0022 from './0022_graceful_elektra.sql';
 import m0023 from './0023_amused_rhino.sql';
+import m0024 from './0024_watery_madelyne_pryor.sql';
 
   export default {
     journal,
@@ -52,7 +53,8 @@ m0019,
 m0020,
 m0021,
 m0022,
-m0023
+m0023,
+m0024
     }
   }
   

--- a/src/app/(tabs)/(home)/(settings)/settings.ios.tsx
+++ b/src/app/(tabs)/(home)/(settings)/settings.ios.tsx
@@ -64,10 +64,7 @@ export default function SettingsRoute() {
       // Optimistically update local state
       setMotionToggle(enabled);
 
-      const result = await setSleepTimerMotionDetectionEnabled(
-        session,
-        enabled,
-      );
+      const result = await setSleepTimerMotionDetectionEnabled(enabled);
 
       // If failed, reset local state
       if (!result.success) {

--- a/src/app/(tabs)/(home)/(settings)/settings.tsx
+++ b/src/app/(tabs)/(home)/(settings)/settings.tsx
@@ -72,14 +72,10 @@ export default function SettingsRoute() {
     router.push("/sleep-timer");
   }, []);
 
-  const handleMotionDetectionToggle = useCallback(
-    async (enabled: boolean) => {
-      if (!session) return;
-      // On Android, this always succeeds (accelerometer doesn't need permission)
-      await setSleepTimerMotionDetectionEnabled(session, enabled);
-    },
-    [session],
-  );
+  const handleMotionDetectionToggle = useCallback(async (enabled: boolean) => {
+    // On Android, this always succeeds (accelerometer doesn't need permission)
+    await setSleepTimerMotionDetectionEnabled(enabled);
+  }, []);
 
   const [syncing, setSyncing] = useState(false);
 

--- a/src/app/playback-rate.tsx
+++ b/src/app/playback-rate.tsx
@@ -46,13 +46,13 @@ export default function PlaybackRateRoute() {
   const setPlaybackRateAndDisplay = useCallback(
     (value: number) => {
       setDisplayPlaybackRate(value);
-      if (isSettingsMode && session) {
-        setPreferredPlaybackRate(session, value);
+      if (isSettingsMode) {
+        setPreferredPlaybackRate(value);
       } else {
         Player.setPlaybackRate(value);
       }
     },
-    [isSettingsMode, session, setDisplayPlaybackRate],
+    [isSettingsMode, setDisplayPlaybackRate],
   );
 
   if (!session) return null;

--- a/src/app/sleep-timer.tsx
+++ b/src/app/sleep-timer.tsx
@@ -57,19 +57,17 @@ export default function SleepTimerRoute() {
   const setSleepTimerSecondsAndDisplay = useCallback(
     (value: number) => {
       setDisplaySleepTimerSeconds(value);
-      if (session) setSleepTimerTime(session, value);
+      setSleepTimerTime(value);
     },
-    [session, setDisplaySleepTimerSeconds],
+    [setDisplaySleepTimerSeconds],
   );
 
   const handleMotionDetectionToggle = useCallback(
     async (value: boolean) => {
-      if (!session) return;
-
       // Optimistic update
       setDisplayMotionDetectionEnabled(value);
 
-      const result = await setSleepTimerMotionDetectionEnabled(session, value);
+      const result = await setSleepTimerMotionDetectionEnabled(value);
 
       if (!result.success) {
         // Revert optimistic update
@@ -87,7 +85,7 @@ export default function SleepTimerRoute() {
         }
       }
     },
-    [session, setDisplayMotionDetectionEnabled],
+    [setDisplayMotionDetectionEnabled],
   );
 
   if (!session) return null;
@@ -174,7 +172,7 @@ export default function SleepTimerRoute() {
             thumbColor={Colors.zinc[100]}
             value={sleepTimerEnabled}
             onValueChange={(value) => {
-              setSleepTimerEnabled(session, value);
+              setSleepTimerEnabled(value);
             }}
           />
         </View>

--- a/src/components/screens/tab-bar-with-player/PlayerSettingButtons.tsx
+++ b/src/components/screens/tab-bar-with-player/PlayerSettingButtons.tsx
@@ -7,7 +7,6 @@ import { useShallow } from "zustand/shallow";
 
 import { IconButton } from "@/components/IconButton";
 import { setSleepTimerEnabled } from "@/services/sleep-timer-service";
-import { useSession } from "@/stores/session";
 import {
   selectIsMotionPausingTimer,
   useSleepTimer,
@@ -27,7 +26,6 @@ export function PlayerSettingButtons() {
 }
 
 function SleepTimerButton() {
-  const session = useSession((state) => state.session);
   const sleepTimerEnabled = useSleepTimer((state) => state.sleepTimerEnabled);
   const isMotionPausingTimer = useSleepTimer(selectIsMotionPausingTimer);
 
@@ -42,7 +40,7 @@ function SleepTimerButton() {
           router.navigate("/sleep-timer");
         }}
         onLongPress={() => {
-          if (session) setSleepTimerEnabled(session, !sleepTimerEnabled);
+          setSleepTimerEnabled(!sleepTimerEnabled);
           Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
         }}
       >

--- a/src/db/__tests__/factories.test.ts
+++ b/src/db/__tests__/factories.test.ts
@@ -4,7 +4,7 @@ import {
   createBook,
   createBookAuthor,
   createDownload,
-  createLocalUserSettings,
+  createLocalSettings,
   createMedia,
   createMediaNarrator,
   createNarrator,
@@ -262,18 +262,18 @@ describe("test factories", () => {
     });
   });
 
-  describe("user settings", () => {
-    it("creates local user settings with defaults", async () => {
+  describe("local settings", () => {
+    it("creates local settings with defaults", async () => {
       const db = getDb();
-      const settings = await createLocalUserSettings(db);
+      const settings = await createLocalSettings(db);
 
-      expect(settings.userEmail).toBe(DEFAULT_TEST_SESSION.email);
+      expect(settings.id).toBe("local");
       expect(settings.preferredPlaybackRate).toBe(1);
     });
 
-    it("creates local user settings with overrides", async () => {
+    it("creates local settings with overrides", async () => {
       const db = getDb();
-      const settings = await createLocalUserSettings(db, {
+      const settings = await createLocalSettings(db, {
         preferredPlaybackRate: 1.5,
         sleepTimerEnabled: true,
       });

--- a/src/db/__tests__/local-settings-migration.test.ts
+++ b/src/db/__tests__/local-settings-migration.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for the migration that collapses the per-email `local_user_settings`
+ * table into the device-scoped `local_settings` singleton.
+ *
+ * Applies all migrations up to (but not including) the collapse migration,
+ * seeds legacy data, then applies the collapse migration and verifies the
+ * surviving row.
+ */
+import Database from "better-sqlite3";
+import * as fs from "fs";
+import * as path from "path";
+
+const MIGRATIONS_DIR = path.join(__dirname, "../../../drizzle");
+const COLLAPSE_MIGRATION_PREFIX = "0023_";
+
+function readJournalTags(): string[] {
+  const journalPath = path.join(MIGRATIONS_DIR, "meta/_journal.json");
+  const journal = JSON.parse(fs.readFileSync(journalPath, "utf-8"));
+  return journal.entries.map((entry: { tag: string }) => entry.tag);
+}
+
+function applyMigration(sqlite: Database.Database, tag: string): void {
+  const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, `${tag}.sql`), "utf-8");
+  const statements = sql
+    .split("--> statement-breakpoint")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  for (const statement of statements) {
+    sqlite.exec(statement);
+  }
+}
+
+/**
+ * Create an in-memory database migrated up to, but not including, the
+ * collapse migration. Returns the database and the collapse migration's tag.
+ */
+function createLegacyDatabase(): {
+  sqlite: Database.Database;
+  collapseTag: string;
+} {
+  const tags = readJournalTags();
+  const collapseTag = tags.find((tag) =>
+    tag.startsWith(COLLAPSE_MIGRATION_PREFIX),
+  )!;
+  expect(collapseTag).toBeDefined();
+
+  const sqlite = new Database(":memory:");
+  for (const tag of tags) {
+    if (tag === collapseTag) break;
+    applyMigration(sqlite, tag);
+  }
+
+  return { sqlite, collapseTag };
+}
+
+function insertLegacySettings(
+  sqlite: Database.Database,
+  userEmail: string,
+  rate: number,
+  sleepTimer: number,
+): void {
+  sqlite
+    .prepare(
+      `INSERT INTO local_user_settings
+         (user_email, preferred_playback_rate, sleep_timer, sleep_timer_enabled, sleep_timer_motion_detection_enabled)
+       VALUES (?, ?, ?, 1, 0)`,
+    )
+    .run(userEmail, rate, sleepTimer);
+}
+
+function insertServerProfile(
+  sqlite: Database.Database,
+  url: string,
+  userEmail: string,
+  lastSyncTime: number | null,
+): void {
+  sqlite
+    .prepare(
+      `INSERT INTO server_profiles (url, user_email, last_sync_time) VALUES (?, ?, ?)`,
+    )
+    .run(url, userEmail, lastSyncTime);
+}
+
+function getLocalSettingsRows(sqlite: Database.Database) {
+  return sqlite.prepare(`SELECT * FROM local_settings`).all() as {
+    id: string;
+    preferred_playback_rate: number;
+    sleep_timer: number;
+    sleep_timer_enabled: number;
+    sleep_timer_motion_detection_enabled: number;
+    sleep_timer_trigger_time: number | null;
+  }[];
+}
+
+describe("local settings collapse migration", () => {
+  it("drops the legacy table and leaves the new table empty on a fresh install", () => {
+    const { sqlite, collapseTag } = createLegacyDatabase();
+
+    applyMigration(sqlite, collapseTag);
+
+    expect(getLocalSettingsRows(sqlite)).toHaveLength(0);
+    expect(() => sqlite.exec("SELECT * FROM local_user_settings")).toThrow();
+    sqlite.close();
+  });
+
+  it("carries over the single existing settings row", () => {
+    const { sqlite, collapseTag } = createLegacyDatabase();
+    insertLegacySettings(sqlite, "user@example.com", 1.25, 600);
+
+    applyMigration(sqlite, collapseTag);
+
+    const rows = getLocalSettingsRows(sqlite);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.id).toBe("local");
+    expect(rows[0]!.preferred_playback_rate).toBe(1.25);
+    expect(rows[0]!.sleep_timer).toBe(600);
+    expect(rows[0]!.sleep_timer_enabled).toBe(1);
+    sqlite.close();
+  });
+
+  it("keeps the row of the most recently synced account when several exist", () => {
+    const { sqlite, collapseTag } = createLegacyDatabase();
+    // stale@example.com signed in most recently (higher rowid) but
+    // active@example.com synced more recently
+    insertLegacySettings(sqlite, "active@example.com", 1.5, 900);
+    insertLegacySettings(sqlite, "stale@example.com", 2.0, 300);
+    insertServerProfile(
+      sqlite,
+      "https://a.example",
+      "active@example.com",
+      2000,
+    );
+    insertServerProfile(sqlite, "https://b.example", "stale@example.com", 1000);
+
+    applyMigration(sqlite, collapseTag);
+
+    const rows = getLocalSettingsRows(sqlite);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.preferred_playback_rate).toBe(1.5);
+    expect(rows[0]!.sleep_timer).toBe(900);
+    sqlite.close();
+  });
+
+  it("falls back to the most recently created row when no profiles exist", () => {
+    const { sqlite, collapseTag } = createLegacyDatabase();
+    insertLegacySettings(sqlite, "old@example.com", 1.0, 300);
+    insertLegacySettings(sqlite, "new@example.com", 1.75, 1200);
+
+    applyMigration(sqlite, collapseTag);
+
+    const rows = getLocalSettingsRows(sqlite);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.preferred_playback_rate).toBe(1.75);
+    expect(rows[0]!.sleep_timer).toBe(1200);
+    sqlite.close();
+  });
+
+  it("prefers a synced account over accounts that never synced", () => {
+    const { sqlite, collapseTag } = createLegacyDatabase();
+    insertLegacySettings(sqlite, "synced@example.com", 1.5, 900);
+    insertLegacySettings(sqlite, "never-synced@example.com", 2.0, 300);
+    insertServerProfile(
+      sqlite,
+      "https://a.example",
+      "synced@example.com",
+      2000,
+    );
+    insertServerProfile(
+      sqlite,
+      "https://b.example",
+      "never-synced@example.com",
+      null,
+    );
+
+    applyMigration(sqlite, collapseTag);
+
+    const rows = getLocalSettingsRows(sqlite);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.preferred_playback_rate).toBe(1.5);
+    sqlite.close();
+  });
+});

--- a/src/db/__tests__/settings.test.ts
+++ b/src/db/__tests__/settings.test.ts
@@ -11,22 +11,18 @@ import {
   setSleepTimerTime,
 } from "@/db/settings";
 import { setupTestDatabase } from "@test/db-test-utils";
-import { createLocalUserSettings, DEFAULT_TEST_SESSION } from "@test/factories";
+import { createLocalSettings } from "@test/factories";
 
 const { getDb } = setupTestDatabase();
-
-const userEmail = DEFAULT_TEST_SESSION.email;
 
 describe("settings", () => {
   describe("setPreferredPlaybackRate", () => {
     it("creates settings record if none exists", async () => {
       const db = getDb();
 
-      await setPreferredPlaybackRate(userEmail, 1.5);
+      await setPreferredPlaybackRate(1.5);
 
-      const settings = await db.query.localUserSettings.findFirst({
-        where: (s, { eq }) => eq(s.userEmail, userEmail),
-      });
+      const settings = await db.query.localSettings.findFirst();
 
       expect(settings).toBeDefined();
       expect(settings?.preferredPlaybackRate).toBe(1.5);
@@ -34,34 +30,28 @@ describe("settings", () => {
 
     it("updates existing settings record", async () => {
       const db = getDb();
-      await createLocalUserSettings(db, {
-        userEmail,
+      await createLocalSettings(db, {
         preferredPlaybackRate: 1.0,
       });
 
-      await setPreferredPlaybackRate(userEmail, 2.0);
+      await setPreferredPlaybackRate(2.0);
 
-      const settings = await db.query.localUserSettings.findFirst({
-        where: (s, { eq }) => eq(s.userEmail, userEmail),
-      });
+      const settings = await db.query.localSettings.findFirst();
 
       expect(settings?.preferredPlaybackRate).toBe(2.0);
     });
 
     it("does not affect other settings when updating", async () => {
       const db = getDb();
-      await createLocalUserSettings(db, {
-        userEmail,
+      await createLocalSettings(db, {
         preferredPlaybackRate: 1.0,
         sleepTimer: 900,
         sleepTimerEnabled: true,
       });
 
-      await setPreferredPlaybackRate(userEmail, 1.75);
+      await setPreferredPlaybackRate(1.75);
 
-      const settings = await db.query.localUserSettings.findFirst({
-        where: (s, { eq }) => eq(s.userEmail, userEmail),
-      });
+      const settings = await db.query.localSettings.findFirst();
 
       expect(settings?.preferredPlaybackRate).toBe(1.75);
       expect(settings?.sleepTimer).toBe(900);
@@ -73,11 +63,9 @@ describe("settings", () => {
     it("creates settings record if none exists", async () => {
       const db = getDb();
 
-      await setSleepTimerEnabled(userEmail, true);
+      await setSleepTimerEnabled(true);
 
-      const settings = await db.query.localUserSettings.findFirst({
-        where: (s, { eq }) => eq(s.userEmail, userEmail),
-      });
+      const settings = await db.query.localSettings.findFirst();
 
       expect(settings).toBeDefined();
       expect(settings?.sleepTimerEnabled).toBe(true);
@@ -85,32 +73,26 @@ describe("settings", () => {
 
     it("updates existing settings record", async () => {
       const db = getDb();
-      await createLocalUserSettings(db, {
-        userEmail,
+      await createLocalSettings(db, {
         sleepTimerEnabled: false,
       });
 
-      await setSleepTimerEnabled(userEmail, true);
+      await setSleepTimerEnabled(true);
 
-      const settings = await db.query.localUserSettings.findFirst({
-        where: (s, { eq }) => eq(s.userEmail, userEmail),
-      });
+      const settings = await db.query.localSettings.findFirst();
 
       expect(settings?.sleepTimerEnabled).toBe(true);
     });
 
     it("can disable sleep timer", async () => {
       const db = getDb();
-      await createLocalUserSettings(db, {
-        userEmail,
+      await createLocalSettings(db, {
         sleepTimerEnabled: true,
       });
 
-      await setSleepTimerEnabled(userEmail, false);
+      await setSleepTimerEnabled(false);
 
-      const settings = await db.query.localUserSettings.findFirst({
-        where: (s, { eq }) => eq(s.userEmail, userEmail),
-      });
+      const settings = await db.query.localSettings.findFirst();
 
       expect(settings?.sleepTimerEnabled).toBe(false);
     });
@@ -120,11 +102,9 @@ describe("settings", () => {
     it("creates settings record if none exists", async () => {
       const db = getDb();
 
-      await setSleepTimerTime(userEmail, 1800);
+      await setSleepTimerTime(1800);
 
-      const settings = await db.query.localUserSettings.findFirst({
-        where: (s, { eq }) => eq(s.userEmail, userEmail),
-      });
+      const settings = await db.query.localSettings.findFirst();
 
       expect(settings).toBeDefined();
       expect(settings?.sleepTimer).toBe(1800);
@@ -132,16 +112,13 @@ describe("settings", () => {
 
     it("updates existing settings record", async () => {
       const db = getDb();
-      await createLocalUserSettings(db, {
-        userEmail,
+      await createLocalSettings(db, {
         sleepTimer: 600,
       });
 
-      await setSleepTimerTime(userEmail, 1200);
+      await setSleepTimerTime(1200);
 
-      const settings = await db.query.localUserSettings.findFirst({
-        where: (s, { eq }) => eq(s.userEmail, userEmail),
-      });
+      const settings = await db.query.localSettings.findFirst();
 
       expect(settings?.sleepTimer).toBe(1200);
     });
@@ -151,11 +128,9 @@ describe("settings", () => {
     it("creates settings record if none exists", async () => {
       const db = getDb();
 
-      await setSleepTimerMotionDetectionEnabled(userEmail, true);
+      await setSleepTimerMotionDetectionEnabled(true);
 
-      const settings = await db.query.localUserSettings.findFirst({
-        where: (s, { eq }) => eq(s.userEmail, userEmail),
-      });
+      const settings = await db.query.localSettings.findFirst();
 
       expect(settings).toBeDefined();
       expect(settings?.sleepTimerMotionDetectionEnabled).toBe(true);
@@ -163,50 +138,41 @@ describe("settings", () => {
 
     it("updates existing settings record", async () => {
       const db = getDb();
-      await createLocalUserSettings(db, {
-        userEmail,
+      await createLocalSettings(db, {
         sleepTimerMotionDetectionEnabled: false,
       });
 
-      await setSleepTimerMotionDetectionEnabled(userEmail, true);
+      await setSleepTimerMotionDetectionEnabled(true);
 
-      const settings = await db.query.localUserSettings.findFirst({
-        where: (s, { eq }) => eq(s.userEmail, userEmail),
-      });
+      const settings = await db.query.localSettings.findFirst();
 
       expect(settings?.sleepTimerMotionDetectionEnabled).toBe(true);
     });
 
     it("can disable motion detection", async () => {
       const db = getDb();
-      await createLocalUserSettings(db, {
-        userEmail,
+      await createLocalSettings(db, {
         sleepTimerMotionDetectionEnabled: true,
       });
 
-      await setSleepTimerMotionDetectionEnabled(userEmail, false);
+      await setSleepTimerMotionDetectionEnabled(false);
 
-      const settings = await db.query.localUserSettings.findFirst({
-        where: (s, { eq }) => eq(s.userEmail, userEmail),
-      });
+      const settings = await db.query.localSettings.findFirst();
 
       expect(settings?.sleepTimerMotionDetectionEnabled).toBe(false);
     });
 
     it("does not affect other settings when updating", async () => {
       const db = getDb();
-      await createLocalUserSettings(db, {
-        userEmail,
+      await createLocalSettings(db, {
         sleepTimer: 900,
         sleepTimerEnabled: true,
         sleepTimerMotionDetectionEnabled: false,
       });
 
-      await setSleepTimerMotionDetectionEnabled(userEmail, true);
+      await setSleepTimerMotionDetectionEnabled(true);
 
-      const settings = await db.query.localUserSettings.findFirst({
-        where: (s, { eq }) => eq(s.userEmail, userEmail),
-      });
+      const settings = await db.query.localSettings.findFirst();
 
       expect(settings?.sleepTimerMotionDetectionEnabled).toBe(true);
       expect(settings?.sleepTimer).toBe(900);
@@ -216,7 +182,7 @@ describe("settings", () => {
 
   describe("getSleepTimerSettings", () => {
     it("returns defaults when no settings exist", async () => {
-      const settings = await getSleepTimerSettings(userEmail);
+      const settings = await getSleepTimerSettings();
 
       expect(settings.sleepTimer).toBe(DEFAULT_SLEEP_TIMER_SECONDS);
       expect(settings.sleepTimerEnabled).toBe(DEFAULT_SLEEP_TIMER_ENABLED);
@@ -227,14 +193,13 @@ describe("settings", () => {
 
     it("returns saved settings when they exist", async () => {
       const db = getDb();
-      await createLocalUserSettings(db, {
-        userEmail,
+      await createLocalSettings(db, {
         sleepTimer: 900,
         sleepTimerEnabled: true,
         sleepTimerMotionDetectionEnabled: true,
       });
 
-      const settings = await getSleepTimerSettings(userEmail);
+      const settings = await getSleepTimerSettings();
 
       expect(settings.sleepTimer).toBe(900);
       expect(settings.sleepTimerEnabled).toBe(true);
@@ -243,15 +208,14 @@ describe("settings", () => {
 
     it("returns only sleep timer related fields", async () => {
       const db = getDb();
-      await createLocalUserSettings(db, {
-        userEmail,
+      await createLocalSettings(db, {
         sleepTimer: 1200,
         sleepTimerEnabled: false,
         sleepTimerMotionDetectionEnabled: true,
         preferredPlaybackRate: 2.0,
       });
 
-      const settings = await getSleepTimerSettings(userEmail);
+      const settings = await getSleepTimerSettings();
 
       // Should only have sleep timer fields, not other settings like playback rate
       expect(Object.keys(settings).sort()).toEqual([
@@ -262,32 +226,6 @@ describe("settings", () => {
       expect(settings.sleepTimer).toBe(1200);
       expect(settings.sleepTimerEnabled).toBe(false);
       expect(settings.sleepTimerMotionDetectionEnabled).toBe(true);
-    });
-
-    it("returns settings for the correct user", async () => {
-      const db = getDb();
-      await createLocalUserSettings(db, {
-        userEmail: "user1@example.com",
-        sleepTimer: 600,
-        sleepTimerEnabled: true,
-        sleepTimerMotionDetectionEnabled: true,
-      });
-      await createLocalUserSettings(db, {
-        userEmail: "user2@example.com",
-        sleepTimer: 1800,
-        sleepTimerEnabled: false,
-        sleepTimerMotionDetectionEnabled: false,
-      });
-
-      const user1Settings = await getSleepTimerSettings("user1@example.com");
-      const user2Settings = await getSleepTimerSettings("user2@example.com");
-
-      expect(user1Settings.sleepTimer).toBe(600);
-      expect(user1Settings.sleepTimerEnabled).toBe(true);
-      expect(user1Settings.sleepTimerMotionDetectionEnabled).toBe(true);
-      expect(user2Settings.sleepTimer).toBe(1800);
-      expect(user2Settings.sleepTimerEnabled).toBe(false);
-      expect(user2Settings.sleepTimerMotionDetectionEnabled).toBe(false);
     });
   });
 });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -628,7 +628,6 @@ export const localSettings = sqliteTable("local_settings", {
   )
     .notNull()
     .default(DEFAULT_SLEEP_TIMER_MOTION_DETECTION_ENABLED),
-  sleepTimerTriggerTime: integer("sleep_timer_trigger_time"),
 });
 
 export const shelvedMedia = sqliteTable(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -610,10 +610,11 @@ export const downloadsRelations = relations(downloads, ({ one }) => ({
   }),
 }));
 
-// Local settings are associated to a user. If you log into a different account,
-// you will have different local settings.
-export const localUserSettings = sqliteTable("local_user_settings", {
-  userEmail: text("user_email").notNull().primaryKey(),
+// Local settings belong to this device, not to any account or server. Whoever
+// holds the phone keeps their playback and sleep timer preferences no matter
+// which server or email they sign in with. The table holds a single row.
+export const localSettings = sqliteTable("local_settings", {
+  id: text("id").notNull().primaryKey().default("local"),
   preferredPlaybackRate: real("preferred_playback_rate").notNull().default(1),
   sleepTimer: integer("sleep_timer")
     .notNull()

--- a/src/db/settings.ts
+++ b/src/db/settings.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 
 import {
   DEFAULT_PREFERRED_PLAYBACK_RATE,
@@ -9,96 +9,86 @@ import {
 import { getDb } from "@/db/db";
 import * as schema from "@/db/schema";
 
-export async function setPreferredPlaybackRate(
-  userEmail: string,
-  rate: number,
-) {
+// The local settings table holds a single device-scoped row
+const SETTINGS_ROW_ID = "local";
+
+export async function setPreferredPlaybackRate(rate: number) {
   await getDb()
-    .insert(schema.localUserSettings)
+    .insert(schema.localSettings)
     .values({
-      userEmail,
+      id: SETTINGS_ROW_ID,
       preferredPlaybackRate: rate,
     })
     .onConflictDoUpdate({
-      target: [schema.localUserSettings.userEmail],
+      target: [schema.localSettings.id],
       set: {
         preferredPlaybackRate: sql`excluded.preferred_playback_rate`,
       },
     });
 }
 
-export async function getPreferredPlaybackRate(
-  userEmail: string,
-): Promise<number> {
-  const response = await getDb().query.localUserSettings.findFirst({
+export async function getPreferredPlaybackRate(): Promise<number> {
+  const response = await getDb().query.localSettings.findFirst({
     columns: {
       preferredPlaybackRate: true,
     },
-    where: eq(schema.localUserSettings.userEmail, userEmail),
   });
 
   return response?.preferredPlaybackRate ?? DEFAULT_PREFERRED_PLAYBACK_RATE;
 }
 
-export async function setSleepTimerEnabled(
-  userEmail: string,
-  enabled: boolean,
-) {
+export async function setSleepTimerEnabled(enabled: boolean) {
   await getDb()
-    .insert(schema.localUserSettings)
+    .insert(schema.localSettings)
     .values({
-      userEmail,
+      id: SETTINGS_ROW_ID,
       sleepTimerEnabled: enabled,
     })
     .onConflictDoUpdate({
-      target: [schema.localUserSettings.userEmail],
+      target: [schema.localSettings.id],
       set: {
         sleepTimerEnabled: sql`excluded.sleep_timer_enabled`,
       },
     });
 }
 
-export async function setSleepTimerTime(userEmail: string, seconds: number) {
+export async function setSleepTimerTime(seconds: number) {
   await getDb()
-    .insert(schema.localUserSettings)
+    .insert(schema.localSettings)
     .values({
-      userEmail,
+      id: SETTINGS_ROW_ID,
       sleepTimer: seconds,
     })
     .onConflictDoUpdate({
-      target: [schema.localUserSettings.userEmail],
+      target: [schema.localSettings.id],
       set: {
         sleepTimer: sql`excluded.sleep_timer`,
       },
     });
 }
 
-export async function setSleepTimerMotionDetectionEnabled(
-  userEmail: string,
-  enabled: boolean,
-) {
+export async function setSleepTimerMotionDetectionEnabled(enabled: boolean) {
   await getDb()
-    .insert(schema.localUserSettings)
+    .insert(schema.localSettings)
     .values({
-      userEmail,
+      id: SETTINGS_ROW_ID,
       sleepTimerMotionDetectionEnabled: enabled,
     })
     .onConflictDoUpdate({
-      target: [schema.localUserSettings.userEmail],
+      target: [schema.localSettings.id],
       set: {
         sleepTimerMotionDetectionEnabled: sql`excluded.sleep_timer_motion_detection_enabled`,
       },
     });
 }
 
-export async function getSleepTimerSettings(userEmail: string) {
-  const response = await getDb().query.localUserSettings.findFirst({
+export async function getSleepTimerSettings() {
+  const response = await getDb().query.localSettings.findFirst({
     columns: {
       sleepTimer: true,
       sleepTimerEnabled: true,
       sleepTimerMotionDetectionEnabled: true,
     },
-    where: eq(schema.localUserSettings.userEmail, userEmail),
   });
 
   if (response) {

--- a/src/services/__tests__/playback-controls.test.ts
+++ b/src/services/__tests__/playback-controls.test.ts
@@ -39,7 +39,7 @@ import {
 import { setupTestDatabase } from "@test/db-test-utils";
 import {
   createBook,
-  createLocalUserSettings,
+  createLocalSettings,
   createMedia,
   createPlaythrough,
   DEFAULT_TEST_SESSION,
@@ -101,8 +101,8 @@ async function createFullPlaythroughSetup(
     playbackRate: options.rate,
   });
 
-  // Create user settings for active playthrough storage
-  await createLocalUserSettings(db);
+  // Create local settings for active playthrough storage
+  await createLocalSettings(db);
 
   return { book, media, playthrough };
 }

--- a/src/services/__tests__/sleep-timer-service.test.ts
+++ b/src/services/__tests__/sleep-timer-service.test.ts
@@ -33,7 +33,7 @@ import {
 } from "@/stores/track-player";
 import { setupTestDatabase } from "@test/db-test-utils";
 import {
-  createLocalUserSettings,
+  createLocalSettings,
   createMedia,
   DEFAULT_TEST_SESSION,
 } from "@test/factories";
@@ -95,14 +95,13 @@ describe("sleep-timer-service", () => {
   describe("initialize", () => {
     it("loads settings from database and sets store state", async () => {
       const db = getDb();
-      await createLocalUserSettings(db, {
-        userEmail: session.email,
+      await createLocalSettings(db, {
         sleepTimer: 1800,
         sleepTimerEnabled: true,
         sleepTimerMotionDetectionEnabled: true,
       });
 
-      await sleepTimerService.initialize(session);
+      await sleepTimerService.initialize();
 
       const state = useSleepTimer.getState();
       expect(state.initialized).toBe(true);
@@ -112,7 +111,7 @@ describe("sleep-timer-service", () => {
     });
 
     it("uses defaults when no settings exist in database", async () => {
-      await sleepTimerService.initialize(session);
+      await sleepTimerService.initialize();
 
       const state = useSleepTimer.getState();
       expect(state.initialized).toBe(true);
@@ -126,7 +125,7 @@ describe("sleep-timer-service", () => {
     it("skips if already initialized", async () => {
       useSleepTimer.setState({ initialized: true, sleepTimer: 999 });
 
-      await sleepTimerService.initialize(session);
+      await sleepTimerService.initialize();
 
       // Should not have changed the value
       expect(useSleepTimer.getState().sleepTimer).toBe(999);
@@ -135,22 +134,20 @@ describe("sleep-timer-service", () => {
 
   describe("setSleepTimerEnabled", () => {
     beforeEach(async () => {
-      await sleepTimerService.initialize(session);
+      await sleepTimerService.initialize();
     });
 
     it("updates store state", async () => {
-      await sleepTimerService.setSleepTimerEnabled(session, true);
+      await sleepTimerService.setSleepTimerEnabled(true);
 
       expect(useSleepTimer.getState().sleepTimerEnabled).toBe(true);
     });
 
     it("persists to database", async () => {
-      await sleepTimerService.setSleepTimerEnabled(session, true);
+      await sleepTimerService.setSleepTimerEnabled(true);
 
       const db = getDb();
-      const settings = await db.query.localUserSettings.findFirst({
-        where: (s, { eq }) => eq(s.userEmail, session.email),
-      });
+      const settings = await db.query.localSettings.findFirst();
       expect(settings?.sleepTimerEnabled).toBe(true);
     });
 
@@ -159,7 +156,7 @@ describe("sleep-timer-service", () => {
       await setupLoadedPlaythrough({ position: 100 });
       await trackPlayerService.play(PlayPauseSource.USER);
 
-      await sleepTimerService.setSleepTimerEnabled(session, true);
+      await sleepTimerService.setSleepTimerEnabled(true);
 
       // Trigger time should be set
       const triggerTime = useSleepTimer.getState().sleepTimerTriggerTime;
@@ -170,11 +167,11 @@ describe("sleep-timer-service", () => {
       // Set up an active timer with a playing playthrough
       await setupLoadedPlaythrough({ position: 100 });
       await trackPlayerService.play(PlayPauseSource.USER);
-      await sleepTimerService.setSleepTimerEnabled(session, true);
+      await sleepTimerService.setSleepTimerEnabled(true);
       expect(useSleepTimer.getState().sleepTimerTriggerTime).not.toBeNull();
 
       // Disable it
-      await sleepTimerService.setSleepTimerEnabled(session, false);
+      await sleepTimerService.setSleepTimerEnabled(false);
 
       expect(useSleepTimer.getState().sleepTimerTriggerTime).toBeNull();
     });
@@ -182,7 +179,7 @@ describe("sleep-timer-service", () => {
     it("clears trigger time when enabling but not playing", async () => {
       // Load playthrough but don't start playing
       await setupLoadedPlaythrough({ position: 100 });
-      await sleepTimerService.setSleepTimerEnabled(session, true);
+      await sleepTimerService.setSleepTimerEnabled(true);
 
       expect(useSleepTimer.getState().sleepTimerTriggerTime).toBeNull();
     });
@@ -190,22 +187,20 @@ describe("sleep-timer-service", () => {
 
   describe("setSleepTimerTime", () => {
     beforeEach(async () => {
-      await sleepTimerService.initialize(session);
+      await sleepTimerService.initialize();
     });
 
     it("updates store state", async () => {
-      await sleepTimerService.setSleepTimerTime(session, 1200);
+      await sleepTimerService.setSleepTimerTime(1200);
 
       expect(useSleepTimer.getState().sleepTimer).toBe(1200);
     });
 
     it("persists to database", async () => {
-      await sleepTimerService.setSleepTimerTime(session, 1200);
+      await sleepTimerService.setSleepTimerTime(1200);
 
       const db = getDb();
-      const settings = await db.query.localUserSettings.findFirst({
-        where: (s, { eq }) => eq(s.userEmail, session.email),
-      });
+      const settings = await db.query.localSettings.findFirst();
       expect(settings?.sleepTimer).toBe(1200);
     });
 
@@ -213,7 +208,7 @@ describe("sleep-timer-service", () => {
       // Start with an active timer
       await setupLoadedPlaythrough({ position: 100 });
       await trackPlayerService.play(PlayPauseSource.USER);
-      await sleepTimerService.setSleepTimerEnabled(session, true);
+      await sleepTimerService.setSleepTimerEnabled(true);
 
       const originalTriggerTime =
         useSleepTimer.getState().sleepTimerTriggerTime;
@@ -223,7 +218,7 @@ describe("sleep-timer-service", () => {
       jest.advanceTimersByTime(5000);
 
       // Change the duration
-      await sleepTimerService.setSleepTimerTime(session, 1800);
+      await sleepTimerService.setSleepTimerTime(1800);
 
       // Trigger time should have been reset (new time based on new duration)
       const newTriggerTime = useSleepTimer.getState().sleepTimerTriggerTime;
@@ -233,7 +228,7 @@ describe("sleep-timer-service", () => {
 
     it("does not reset trigger time when timer is not active", async () => {
       // Timer not active
-      await sleepTimerService.setSleepTimerTime(session, 1800);
+      await sleepTimerService.setSleepTimerTime(1800);
 
       expect(useSleepTimer.getState().sleepTimerTriggerTime).toBeNull();
     });
@@ -241,14 +236,11 @@ describe("sleep-timer-service", () => {
 
   describe("setSleepTimerMotionDetectionEnabled", () => {
     beforeEach(async () => {
-      await sleepTimerService.initialize(session);
+      await sleepTimerService.initialize();
     });
 
     it("updates store state", async () => {
-      await sleepTimerService.setSleepTimerMotionDetectionEnabled(
-        session,
-        true,
-      );
+      await sleepTimerService.setSleepTimerMotionDetectionEnabled(true);
 
       expect(useSleepTimer.getState().sleepTimerMotionDetectionEnabled).toBe(
         true,
@@ -256,22 +248,17 @@ describe("sleep-timer-service", () => {
     });
 
     it("persists to database", async () => {
-      await sleepTimerService.setSleepTimerMotionDetectionEnabled(
-        session,
-        true,
-      );
+      await sleepTimerService.setSleepTimerMotionDetectionEnabled(true);
 
       const db = getDb();
-      const settings = await db.query.localUserSettings.findFirst({
-        where: (s, { eq }) => eq(s.userEmail, session.email),
-      });
+      const settings = await db.query.localSettings.findFirst();
       expect(settings?.sleepTimerMotionDetectionEnabled).toBe(true);
     });
 
     it("starts motion detection when enabled and timer is active", async () => {
       // Start with sleep timer enabled and playing
       await setupLoadedPlaythrough({ position: 100 });
-      await sleepTimerService.setSleepTimerEnabled(session, true);
+      await sleepTimerService.setSleepTimerEnabled(true);
       await trackPlayerService.play(PlayPauseSource.USER);
       await jest.advanceTimersByTimeAsync(100);
 
@@ -279,10 +266,7 @@ describe("sleep-timer-service", () => {
       expect(activityTrackerFake.getState().isTracking).toBe(false);
 
       // Enable motion detection
-      await sleepTimerService.setSleepTimerMotionDetectionEnabled(
-        session,
-        true,
-      );
+      await sleepTimerService.setSleepTimerMotionDetectionEnabled(true);
 
       // Motion detection should now be started
       expect(activityTrackerFake.getState().isTracking).toBe(true);
@@ -290,12 +274,9 @@ describe("sleep-timer-service", () => {
 
     it("stops motion detection when disabled and timer is active", async () => {
       // Start with motion detection enabled
-      await sleepTimerService.setSleepTimerMotionDetectionEnabled(
-        session,
-        true,
-      );
+      await sleepTimerService.setSleepTimerMotionDetectionEnabled(true);
       await setupLoadedPlaythrough({ position: 100 });
-      await sleepTimerService.setSleepTimerEnabled(session, true);
+      await sleepTimerService.setSleepTimerEnabled(true);
       await trackPlayerService.play(PlayPauseSource.USER);
       await jest.advanceTimersByTimeAsync(100);
 
@@ -303,10 +284,7 @@ describe("sleep-timer-service", () => {
       expect(activityTrackerFake.getState().isTracking).toBe(true);
 
       // Disable motion detection
-      await sleepTimerService.setSleepTimerMotionDetectionEnabled(
-        session,
-        false,
-      );
+      await sleepTimerService.setSleepTimerMotionDetectionEnabled(false);
 
       // Motion detection should be stopped
       expect(activityTrackerFake.getState().isTracking).toBe(false);
@@ -314,10 +292,7 @@ describe("sleep-timer-service", () => {
 
     it("does not start motion detection when timer is not active", async () => {
       // Enable motion detection without timer active
-      await sleepTimerService.setSleepTimerMotionDetectionEnabled(
-        session,
-        true,
-      );
+      await sleepTimerService.setSleepTimerMotionDetectionEnabled(true);
 
       // Motion detection should not start (not playing)
       expect(activityTrackerFake.getState().isTracking).toBe(false);
@@ -325,13 +300,10 @@ describe("sleep-timer-service", () => {
 
     it("timer starts when disabling motion detection while timer was stopped due to movement", async () => {
       // Enable motion detection
-      await sleepTimerService.setSleepTimerMotionDetectionEnabled(
-        session,
-        true,
-      );
+      await sleepTimerService.setSleepTimerMotionDetectionEnabled(true);
 
       await setupLoadedPlaythrough({ position: 100 });
-      await sleepTimerService.setSleepTimerEnabled(session, true);
+      await sleepTimerService.setSleepTimerEnabled(true);
       await trackPlayerService.play(PlayPauseSource.USER);
       await jest.advanceTimersByTimeAsync(100);
 
@@ -342,10 +314,7 @@ describe("sleep-timer-service", () => {
       expect(useSleepTimer.getState().sleepTimerTriggerTime).toBeNull();
 
       // Now disable motion detection
-      await sleepTimerService.setSleepTimerMotionDetectionEnabled(
-        session,
-        false,
-      );
+      await sleepTimerService.setSleepTimerMotionDetectionEnabled(false);
 
       // Timer should now start (motion detection disabled = movement doesn't matter)
       expect(useSleepTimer.getState().sleepTimerTriggerTime).not.toBeNull();
@@ -354,13 +323,10 @@ describe("sleep-timer-service", () => {
 
   describe("motion detection integration", () => {
     beforeEach(async () => {
-      await sleepTimerService.initialize(session);
+      await sleepTimerService.initialize();
       // Enable motion detection
-      await sleepTimerService.setSleepTimerMotionDetectionEnabled(
-        session,
-        true,
-      );
-      await sleepTimerService.setSleepTimerEnabled(session, true);
+      await sleepTimerService.setSleepTimerMotionDetectionEnabled(true);
+      await sleepTimerService.setSleepTimerEnabled(true);
     });
 
     it("starts motion detection when playback starts and motion detection is enabled", async () => {
@@ -385,10 +351,7 @@ describe("sleep-timer-service", () => {
 
     it("does not start motion detection when motion detection is disabled", async () => {
       // Disable motion detection
-      await sleepTimerService.setSleepTimerMotionDetectionEnabled(
-        session,
-        false,
-      );
+      await sleepTimerService.setSleepTimerMotionDetectionEnabled(false);
 
       await setupLoadedPlaythrough({ position: 100 });
       await trackPlayerService.play(PlayPauseSource.USER);
@@ -400,12 +363,9 @@ describe("sleep-timer-service", () => {
 
   describe("isStationary state and timer behavior", () => {
     beforeEach(async () => {
-      await sleepTimerService.initialize(session);
-      await sleepTimerService.setSleepTimerMotionDetectionEnabled(
-        session,
-        true,
-      );
-      await sleepTimerService.setSleepTimerEnabled(session, true);
+      await sleepTimerService.initialize();
+      await sleepTimerService.setSleepTimerMotionDetectionEnabled(true);
+      await sleepTimerService.setSleepTimerEnabled(true);
       await setupLoadedPlaythrough({ position: 100 });
     });
 
@@ -492,8 +452,8 @@ describe("sleep-timer-service", () => {
 
   describe("play/pause event handling", () => {
     beforeEach(async () => {
-      await sleepTimerService.initialize(session);
-      await sleepTimerService.setSleepTimerEnabled(session, true);
+      await sleepTimerService.initialize();
+      await sleepTimerService.setSleepTimerEnabled(true);
       await setupLoadedPlaythrough({ position: 100 });
     });
 
@@ -548,8 +508,8 @@ describe("sleep-timer-service", () => {
 
   describe("seek event handling", () => {
     beforeEach(async () => {
-      await sleepTimerService.initialize(session);
-      await sleepTimerService.setSleepTimerEnabled(session, true);
+      await sleepTimerService.initialize();
+      await sleepTimerService.setSleepTimerEnabled(true);
 
       // Load playthrough and start playing
       await setupLoadedPlaythrough({ position: 100 });
@@ -615,9 +575,9 @@ describe("sleep-timer-service", () => {
 
   describe("timer check and trigger", () => {
     beforeEach(async () => {
-      await sleepTimerService.initialize(session);
-      await sleepTimerService.setSleepTimerTime(session, 60); // 60 second timer for easier testing
-      await sleepTimerService.setSleepTimerEnabled(session, true);
+      await sleepTimerService.initialize();
+      await sleepTimerService.setSleepTimerTime(60); // 60 second timer for easier testing
+      await sleepTimerService.setSleepTimerEnabled(true);
 
       // Set up loaded playthrough and start playing
       await setupLoadedPlaythrough({ position: 100 });
@@ -671,7 +631,7 @@ describe("sleep-timer-service", () => {
 
   describe("timer not enabled", () => {
     beforeEach(async () => {
-      await sleepTimerService.initialize(session);
+      await sleepTimerService.initialize();
       // Sleep timer is disabled by default
     });
 

--- a/src/services/boot-service.ts
+++ b/src/services/boot-service.ts
@@ -79,8 +79,8 @@ export function useAppBoot() {
       await initializeDownloads(session);
       await initializeTrackPlayer();
       await initializePlayer(session);
-      await initializeSleepTimer(session);
-      await initializePreferredPlaybackRate(session);
+      await initializeSleepTimer();
+      await initializePreferredPlaybackRate();
       await initializeHeartbeat();
       await initializeEventRecording();
 

--- a/src/services/preferred-playback-rate-service.ts
+++ b/src/services/preferred-playback-rate-service.ts
@@ -13,7 +13,6 @@ import {
   resetForTesting as resetPreferredPlaybackRateStore,
   usePreferredPlaybackRate,
 } from "@/stores/preferred-playback-rate";
-import { Session } from "@/types/session";
 import { logBase } from "@/utils/logger";
 
 const log = logBase.extend("preferred-rate");
@@ -23,16 +22,16 @@ const log = logBase.extend("preferred-rate");
 // =============================================================================
 
 /**
- * Initialize the preferred playback rate store. Loads user preference from DB
- * if not already initialized.
+ * Initialize the preferred playback rate store. Loads the device-level
+ * preference from DB if not already initialized.
  */
-export async function initialize(session: Session) {
+export async function initialize() {
   if (isInitialized()) {
     log.debug("Already initialized, skipping");
     return;
   }
 
-  const rate = await getPreferredPlaybackRate(session.email);
+  const rate = await getPreferredPlaybackRate();
   usePreferredPlaybackRate.setState({
     initialized: true,
     preferredPlaybackRate: rate,
@@ -44,11 +43,11 @@ export async function initialize(session: Session) {
 /**
  * Sets the preferred playback rate and persists it to the database.
  */
-export async function setPreferredPlaybackRate(session: Session, rate: number) {
+export async function setPreferredPlaybackRate(rate: number) {
   log.info(`Setting preferred playback rate to ${rate}`);
 
   usePreferredPlaybackRate.setState({ preferredPlaybackRate: rate });
-  await setPreferredPlaybackRateDb(session.email, rate);
+  await setPreferredPlaybackRateDb(rate);
 }
 
 // =============================================================================

--- a/src/services/sleep-timer-service.ts
+++ b/src/services/sleep-timer-service.ts
@@ -40,7 +40,6 @@ import {
   SeekSource,
   useTrackPlayer,
 } from "@/stores/track-player";
-import { Session } from "@/types/session";
 import { logBase } from "@/utils/logger";
 import { subscribeToChange } from "@/utils/subscribe";
 
@@ -78,15 +77,15 @@ function isActivityTrackingActive(): boolean {
 // =============================================================================
 
 /**
- * Initialize the sleep timer service. Loads user preferences from DB.
+ * Initialize the sleep timer service. Loads device-level preferences from DB.
  */
-export async function initialize(session: Session) {
+export async function initialize() {
   if (useSleepTimer.getState().initialized) {
     log.debug("Already initialized, skipping");
     return;
   }
 
-  const settings = await getSleepTimerSettings(session.email);
+  const settings = await getSleepTimerSettings();
   useSleepTimer.setState({
     initialized: true,
     sleepTimer: settings.sleepTimer,
@@ -101,18 +100,18 @@ export async function initialize(session: Session) {
 /**
  * Sets the enabled state for the sleep timer and persists it to the database.
  */
-export async function setSleepTimerEnabled(session: Session, enabled: boolean) {
+export async function setSleepTimerEnabled(enabled: boolean) {
   log.debug(`Setting enabled to ${enabled}`);
   useSleepTimer.setState({ sleepTimerEnabled: enabled });
   await updateTimerState();
-  await setSleepTimerEnabledDb(session.email, enabled);
+  await setSleepTimerEnabledDb(enabled);
 }
 
 /**
  * Sets the duration for the sleep timer and persists it to the database.
  * Resets the trigger time if the timer is currently active.
  */
-export async function setSleepTimerTime(session: Session, seconds: number) {
+export async function setSleepTimerTime(seconds: number) {
   log.debug(`Setting time to ${seconds} seconds`);
 
   const { sleepTimerTriggerTime, sleepTimer: prevSleepTimer } =
@@ -125,7 +124,7 @@ export async function setSleepTimerTime(session: Session, seconds: number) {
     await resetTriggerTime();
   }
 
-  await setSleepTimerTimeDb(session.email, seconds);
+  await setSleepTimerTimeDb(seconds);
 }
 
 /**
@@ -144,7 +143,6 @@ export type MotionDetectionResult = {
  * denies permission, the setting will not be enabled.
  */
 export async function setSleepTimerMotionDetectionEnabled(
-  session: Session,
   enabled: boolean,
 ): Promise<MotionDetectionResult> {
   log.debug(`Setting motion detection to ${enabled}`);
@@ -166,7 +164,7 @@ export async function setSleepTimerMotionDetectionEnabled(
 
   useSleepTimer.setState({ sleepTimerMotionDetectionEnabled: enabled });
   await updateTimerState();
-  await setSleepTimerMotionDetectionEnabledDb(session.email, enabled);
+  await setSleepTimerMotionDetectionEnabledDb(enabled);
   return { success: true };
 }
 

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -719,24 +719,19 @@ export async function createServerProfile(
 // User Settings
 // =============================================================================
 
-type LocalUserSettingsOverrides = Partial<
-  typeof schema.localUserSettings.$inferInsert
->;
+type LocalSettingsOverrides = Partial<typeof schema.localSettings.$inferInsert>;
 
-export async function createLocalUserSettings(
+export async function createLocalSettings(
   db: TestDatabase,
-  overrides: LocalUserSettingsOverrides = {},
-): Promise<typeof schema.localUserSettings.$inferSelect> {
-  const settings: typeof schema.localUserSettings.$inferInsert = {
-    userEmail: DEFAULT_TEST_SESSION.email,
+  overrides: LocalSettingsOverrides = {},
+): Promise<typeof schema.localSettings.$inferSelect> {
+  const settings: typeof schema.localSettings.$inferInsert = {
     ...overrides,
   };
 
-  await db.insert(schema.localUserSettings).values(settings);
+  await db.insert(schema.localSettings).values(settings);
 
-  const result = await db.query.localUserSettings.findFirst({
-    where: (s, { eq }) => eq(s.userEmail, settings.userEmail),
-  });
+  const result = await db.query.localSettings.findFirst();
 
   return result!;
 }


### PR DESCRIPTION
Follow-up to #66 (discussion in review there).

`local_user_settings` was keyed by email, but the intent was always device-level preferences: whoever holds the phone keeps their playback rate and sleep timer no matter which server or account they sign into. With email keying, signing in with a new email silently reset preferences to defaults (modulo the in-memory carryover from the persistent JS context, which lasted only until the process died — and split the persisted values per-email underneath).

## Changes

- **Schema**: `local_user_settings` (PK `user_email`) is replaced by `local_settings`, a single-row table with a constant `id = 'local'`.
- **Migration** (`0023_amused_rhino.sql`): creates the new table, carries data over, drops the old one. When multiple per-email rows exist, the row belonging to the most recently synced `server_profiles` entry wins (best proxy for "the account actually in use"), falling back to the most recently created row. In practice nearly every install has exactly one row.
- **Migration** (`0024_watery_madelyne_pryor.sql`): drops the orphaned `sleep_timer_trigger_time` column. It was persisted in migration 0013 so an armed sleep timer could survive process death, but the architecture rewrite (#54) moved the trigger time to in-memory-only state and removed all DB reads/writes; the column has been write-orphaned since. Done as a follow-up migration rather than by amending 0023, since 0023 was already applied to dev devices.
- **API**: the `userEmail`/`session` parameter is dropped from `db/settings.ts`, the sleep-timer and preferred-playback-rate services (`initialize()` no longer takes a session), and all UI call sites.
- These stores are intentionally **not** reset on sign-out — preferences surviving account changes is now the designed behavior, closing out the caveat noted in #66.

## Tests

New `local-settings-migration.test.ts` exercises the real migration SQL against a database built at the pre-collapse schema: fresh install (no row), single-row carry-over, most-recently-synced account winning over a newer-but-stale row, rowid fallback with no profiles, and synced-beats-never-synced. Existing settings/service/factory tests updated for the device-scoped API. Every test database replays the full migration chain, so 0024 is exercised by all suites.

`npx tsc`, `npm run lint`, and `npm test` (66 suites, 674 tests) all pass.