### PR TITLE
Fix library sync dropping foreign-key changes on existing rows

### DIFF
--- a/src/db/__tests__/sync.test.ts
+++ b/src/db/__tests__/sync.test.ts
@@ -501,6 +501,224 @@ describe("sync", () => {
         expect(books).toHaveLength(1);
         expect(books[0]!.title).toBe("New Title");
       });
+
+      it("updates media-narrator when the narrator is changed on the server", async () => {
+        const db = getDb();
+        const person = createLibraryPerson({ id: "person-1" });
+        const narrator1 = createLibraryNarrator({
+          id: "narrator-1",
+          personId: "person-1",
+        });
+        const narrator2 = createLibraryNarrator({
+          id: "narrator-2",
+          personId: "person-1",
+        });
+        const book = createLibraryBook({ id: "book-1" });
+        const media = createLibraryMedia({ id: "media-1", bookId: "book-1" });
+
+        // First sync: media narrated by narrator-1
+        mockGraphQL(
+          mockFetch,
+          graphqlSuccess({
+            ...emptyLibraryChanges(),
+            peopleChangedSince: [person],
+            narratorsChangedSince: [narrator1, narrator2],
+            booksChangedSince: [book],
+            mediaChangedSince: [media],
+            mediaNarratorsChangedSince: [
+              createLibraryMediaNarrator({
+                id: "mn-1",
+                mediaId: "media-1",
+                narratorId: "narrator-1",
+              }),
+            ],
+          }),
+        );
+        await syncLibrary(session);
+
+        // Second sync: the same join row now points at narrator-2
+        mockGraphQL(
+          mockFetch,
+          graphqlSuccess({
+            ...emptyLibraryChanges(),
+            mediaNarratorsChangedSince: [
+              createLibraryMediaNarrator({
+                id: "mn-1",
+                mediaId: "media-1",
+                narratorId: "narrator-2",
+              }),
+            ],
+          }),
+        );
+        await syncLibrary(session);
+
+        const mediaNarrators = await db.query.mediaNarrators.findMany();
+        expect(mediaNarrators).toHaveLength(1);
+        expect(mediaNarrators[0]!.narratorId).toBe("narrator-2");
+      });
+
+      it("updates book-author when the author is changed on the server", async () => {
+        const db = getDb();
+        const person = createLibraryPerson({ id: "person-1" });
+        const author1 = createLibraryAuthor({
+          id: "author-1",
+          personId: "person-1",
+        });
+        const author2 = createLibraryAuthor({
+          id: "author-2",
+          personId: "person-1",
+        });
+        const book = createLibraryBook({ id: "book-1" });
+
+        mockGraphQL(
+          mockFetch,
+          graphqlSuccess({
+            ...emptyLibraryChanges(),
+            peopleChangedSince: [person],
+            authorsChangedSince: [author1, author2],
+            booksChangedSince: [book],
+            bookAuthorsChangedSince: [
+              createLibraryBookAuthor({
+                id: "ba-1",
+                bookId: "book-1",
+                authorId: "author-1",
+              }),
+            ],
+          }),
+        );
+        await syncLibrary(session);
+
+        mockGraphQL(
+          mockFetch,
+          graphqlSuccess({
+            ...emptyLibraryChanges(),
+            bookAuthorsChangedSince: [
+              createLibraryBookAuthor({
+                id: "ba-1",
+                bookId: "book-1",
+                authorId: "author-2",
+              }),
+            ],
+          }),
+        );
+        await syncLibrary(session);
+
+        const bookAuthors = await db.query.bookAuthors.findMany();
+        expect(bookAuthors).toHaveLength(1);
+        expect(bookAuthors[0]!.authorId).toBe("author-2");
+      });
+
+      it("updates series-book when the series is changed on the server", async () => {
+        const db = getDb();
+        const book = createLibraryBook({ id: "book-1" });
+        const series1 = createLibrarySeries({ id: "series-1" });
+        const series2 = createLibrarySeries({ id: "series-2" });
+
+        mockGraphQL(
+          mockFetch,
+          graphqlSuccess({
+            ...emptyLibraryChanges(),
+            booksChangedSince: [book],
+            seriesChangedSince: [series1, series2],
+            seriesBooksChangedSince: [
+              createLibrarySeriesBook({
+                id: "sb-1",
+                bookId: "book-1",
+                seriesId: "series-1",
+                bookNumber: "3",
+              }),
+            ],
+          }),
+        );
+        await syncLibrary(session);
+
+        mockGraphQL(
+          mockFetch,
+          graphqlSuccess({
+            ...emptyLibraryChanges(),
+            seriesBooksChangedSince: [
+              createLibrarySeriesBook({
+                id: "sb-1",
+                bookId: "book-1",
+                seriesId: "series-2",
+                bookNumber: "1.5",
+              }),
+            ],
+          }),
+        );
+        await syncLibrary(session);
+
+        const seriesBooks = await db.query.seriesBooks.findMany();
+        expect(seriesBooks).toHaveLength(1);
+        expect(seriesBooks[0]!.seriesId).toBe("series-2");
+        expect(seriesBooks[0]!.bookNumber).toBe("1.5");
+      });
+
+      it("updates author's person when changed on the server", async () => {
+        const db = getDb();
+        const person1 = createLibraryPerson({ id: "person-1" });
+        const person2 = createLibraryPerson({ id: "person-2" });
+
+        mockGraphQL(
+          mockFetch,
+          graphqlSuccess({
+            ...emptyLibraryChanges(),
+            peopleChangedSince: [person1, person2],
+            authorsChangedSince: [
+              createLibraryAuthor({ id: "author-1", personId: "person-1" }),
+            ],
+          }),
+        );
+        await syncLibrary(session);
+
+        mockGraphQL(
+          mockFetch,
+          graphqlSuccess({
+            ...emptyLibraryChanges(),
+            authorsChangedSince: [
+              createLibraryAuthor({ id: "author-1", personId: "person-2" }),
+            ],
+          }),
+        );
+        await syncLibrary(session);
+
+        const authors = await db.query.authors.findMany();
+        expect(authors).toHaveLength(1);
+        expect(authors[0]!.personId).toBe("person-2");
+      });
+
+      it("updates narrator's person when changed on the server", async () => {
+        const db = getDb();
+        const person1 = createLibraryPerson({ id: "person-1" });
+        const person2 = createLibraryPerson({ id: "person-2" });
+
+        mockGraphQL(
+          mockFetch,
+          graphqlSuccess({
+            ...emptyLibraryChanges(),
+            peopleChangedSince: [person1, person2],
+            narratorsChangedSince: [
+              createLibraryNarrator({ id: "narrator-1", personId: "person-1" }),
+            ],
+          }),
+        );
+        await syncLibrary(session);
+
+        mockGraphQL(
+          mockFetch,
+          graphqlSuccess({
+            ...emptyLibraryChanges(),
+            narratorsChangedSince: [
+              createLibraryNarrator({ id: "narrator-1", personId: "person-2" }),
+            ],
+          }),
+        );
+        await syncLibrary(session);
+
+        const narrators = await db.query.narrators.findMany();
+        expect(narrators).toHaveLength(1);
+        expect(narrators[0]!.personId).toBe("person-2");
+      });
     });
 
     // =========================================================================

--- a/src/db/sync.ts
+++ b/src/db/sync.ts
@@ -353,6 +353,7 @@ export async function applyLibraryChanges(
         .onConflictDoUpdate({
           target: [schema.authors.url, schema.authors.id],
           set: {
+            personId: sql`excluded.person_id`,
             name: sql`excluded.name`,
             updatedAt: sql`excluded.updated_at`,
           },
@@ -368,6 +369,7 @@ export async function applyLibraryChanges(
         .onConflictDoUpdate({
           target: [schema.narrators.url, schema.narrators.id],
           set: {
+            personId: sql`excluded.person_id`,
             name: sql`excluded.name`,
             updatedAt: sql`excluded.updated_at`,
           },
@@ -400,6 +402,8 @@ export async function applyLibraryChanges(
         .onConflictDoUpdate({
           target: [schema.bookAuthors.url, schema.bookAuthors.id],
           set: {
+            bookId: sql`excluded.book_id`,
+            authorId: sql`excluded.author_id`,
             updatedAt: sql`excluded.updated_at`,
           },
         });
@@ -429,6 +433,8 @@ export async function applyLibraryChanges(
         .onConflictDoUpdate({
           target: [schema.seriesBooks.url, schema.seriesBooks.id],
           set: {
+            bookId: sql`excluded.book_id`,
+            seriesId: sql`excluded.series_id`,
             bookNumber: sql`excluded.book_number`,
             updatedAt: sql`excluded.updated_at`,
           },
@@ -474,6 +480,8 @@ export async function applyLibraryChanges(
         .onConflictDoUpdate({
           target: [schema.mediaNarrators.url, schema.mediaNarrators.id],
           set: {
+            mediaId: sql`excluded.media_id`,
+            narratorId: sql`excluded.narrator_id`,
             updatedAt: sql`excluded.updated_at`,
           },
         });


### PR DESCRIPTION
Fixes ambry-app/ambry#1086

## The bug

Changing a media's narrator on the server never reached the app; the workaround was deleting the narrator, saving, and re-adding.

Root cause: the `onConflictDoUpdate` clauses in `applyLibraryChanges` omitted foreign-key columns. When a join row is edited in place on the server (same row id, new reference), the server correctly sends the row and the app correctly upserts it — but the conflict-update only set `updatedAt`, keeping the stale reference. Delete-then-re-add worked because that path is a deletion event plus a fresh insert.

The omission was systemic, not narrator-specific:

| Table | Dropped on update |
|---|---|
| `mediaNarrators` | `mediaId`, `narratorId` (the reported bug) |
| `bookAuthors` | `bookId`, `authorId` |
| `seriesBooks` | `bookId`, `seriesId` |
| `authors` | `personId` |
| `narrators` | `personId` |

## The fix

Every synced column is now updated on conflict, matching what's inserted. Added regression tests for each affected table (all five fail against the previous code).

## Note on already-affected devices

The fix only applies to rows that change after it ships — a device already holding a stale reference won't re-receive that row, since its `updated_at` hasn't moved. **Force Full Sync** (settings screen) heals a device completely: it discards the sync cursor, so the whole library re-syncs through the corrected upserts.

https://claude.ai/code/session_013Fe6wyFZ9chpUVnGDqyqY9