### PR TITLE
Stop trusting a dead player's progress; fixes streaming seek-to-0

### DIFF
--- a/src/services/__tests__/position-heartbeat.test.ts
+++ b/src/services/__tests__/position-heartbeat.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for position-heartbeat.ts
+ *
+ * Uses Detroit-style testing: we mock only:
+ * - Native modules (react-native-track-player via jest-setup.ts)
+ *
+ * The real track-player store, database code, and service logic runs.
+ */
+
+import { eq } from "drizzle-orm";
+
+import { getPlaythroughWithMedia } from "@/db/playthroughs";
+import * as schema from "@/db/schema";
+import { saveNow } from "@/services/position-heartbeat";
+import * as trackPlayerService from "@/services/track-player-service";
+import {
+  resetForTesting as resetTrackPlayerStore,
+  SeekSource,
+} from "@/stores/track-player";
+import { setupTestDatabase } from "@test/db-test-utils";
+import {
+  createMedia,
+  createPlaythrough,
+  DEFAULT_TEST_SESSION,
+} from "@test/factories";
+import { resetTrackPlayerFake } from "@test/jest-setup";
+
+// Set up fresh test DB
+const { getDb } = setupTestDatabase();
+
+const session = DEFAULT_TEST_SESSION;
+
+async function getCachedPosition(playthroughId: string) {
+  const db = getDb();
+  const cache = await db.query.playthroughStateCache.findFirst({
+    where: eq(schema.playthroughStateCache.playthroughId, playthroughId),
+  });
+  return cache?.position;
+}
+
+describe("position-heartbeat", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetTrackPlayerFake();
+    resetTrackPlayerStore();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("saveNow", () => {
+    it("does nothing when no playthrough is loaded", async () => {
+      await expect(saveNow()).resolves.toBeUndefined();
+    });
+
+    it("saves the current position to the state cache", async () => {
+      const db = getDb();
+      const media = await createMedia(db, { duration: "300.0" });
+      const playthrough = await createPlaythrough(db, {
+        mediaId: media.id,
+        position: 150,
+      });
+      const playthroughWithMedia = await getPlaythroughWithMedia(
+        session,
+        playthrough.id,
+      );
+
+      await trackPlayerService.loadPlaythroughIntoPlayer(
+        session,
+        playthroughWithMedia,
+      );
+      await trackPlayerService.seekTo(200, SeekSource.INTERNAL);
+
+      await saveNow();
+
+      expect(await getCachedPosition(playthrough.id)).toBe(200);
+    });
+
+    it("does not overwrite the cached position with invalid progress", async () => {
+      const db = getDb();
+      // Media with unknown duration: the player never reports a valid
+      // duration, so store progress stays invalid (duration 0) - the same
+      // shape a dead streaming player produces.
+      const media = await createMedia(db, { duration: null });
+      const playthrough = await createPlaythrough(db, {
+        mediaId: media.id,
+        position: 150,
+        cachePosition: 150,
+      });
+      const playthroughWithMedia = await getPlaythroughWithMedia(
+        session,
+        playthrough.id,
+      );
+
+      jest.useFakeTimers();
+      const loadPromise = trackPlayerService.loadPlaythroughIntoPlayer(
+        session,
+        playthroughWithMedia,
+      );
+      await jest.advanceTimersByTimeAsync(60_000);
+      await loadPromise;
+
+      await saveNow();
+
+      // The cached position survives instead of being zeroed
+      expect(await getCachedPosition(playthrough.id)).toBe(150);
+    });
+  });
+});

--- a/src/services/__tests__/seek-service.test.ts
+++ b/src/services/__tests__/seek-service.test.ts
@@ -318,4 +318,34 @@ describe("seek-service", () => {
       expect(lastSeek?.source).toBe(SeekSource.REMOTE);
     });
   });
+
+  describe("seeking while the player has lost its track (streaming stall)", () => {
+    // Regression test for the "seek to 0" progress-loss bug: a streaming
+    // player that errors out after a network failure reports zeroed progress.
+    // A relative seek must base itself on the last-known position, not the
+    // dead player's zeros - previously a jump-back during a stall computed
+    // 0 - 10 and recorded a destructive seek to 0.
+    it("bases a relative seek on the last-known position, not the player's zeros", async () => {
+      await setupLoadedPlaythrough({ position: 150 });
+
+      // The player drops its track and starts reporting zeros
+      trackPlayerFake.setState({ position: 0, duration: 0 });
+
+      const seekPromise = seekService.seekRelative(-10, SeekSource.BUTTON);
+      await jest.advanceTimersByTimeAsync(60_000);
+      await seekPromise;
+
+      const { lastSeek, progress } = useTrackPlayer.getState();
+
+      // The seek lands 10 seconds back from where the user actually was
+      expect(lastSeek?.from).toBe(150);
+      expect(lastSeek?.to).toBe(140);
+
+      // The player was told to seek to 140, not 0
+      expect(trackPlayerFake.getState().position).toBe(140);
+
+      // Store progress still reflects the last-known real position
+      expect(progress.position).toBe(150);
+    });
+  });
 });

--- a/src/services/__tests__/track-player-service.test.ts
+++ b/src/services/__tests__/track-player-service.test.ts
@@ -339,6 +339,56 @@ describe("track-player-service", () => {
     });
   });
 
+  describe("when the player loses its track (streaming failure)", () => {
+    // A streaming player that errors out or drops its item after a network
+    // failure reports zeroed progress. These tests simulate that by zeroing
+    // the fake's position and duration after a successful load.
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("getAccurateProgress falls back to the last-known progress", async () => {
+      const playthrough = await createTestPlaythrough({ position: 150 });
+      await trackPlayerService.loadPlaythroughIntoPlayer(session, playthrough);
+
+      // The player loses its track and starts reporting zeros
+      trackPlayerFake.setState({ position: 0, duration: 0 });
+
+      jest.useFakeTimers();
+      const progressPromise = trackPlayerService.getAccurateProgress();
+      await jest.advanceTimersByTimeAsync(10_000);
+      const progress = await progressPromise;
+
+      expect(progress.position).toBe(150);
+      expect(progress.duration).toBe(300);
+    });
+
+    it("seekTo records the requested position and preserves store progress", async () => {
+      const playthrough = await createTestPlaythrough({ position: 150 });
+      await trackPlayerService.loadPlaythroughIntoPlayer(session, playthrough);
+
+      // The player loses its track and starts reporting zeros
+      trackPlayerFake.setState({ position: 0, duration: 0 });
+
+      jest.useFakeTimers();
+      const seekPromise = trackPlayerService.seekTo(140, SeekSource.BUTTON);
+      await jest.advanceTimersByTimeAsync(60_000);
+      await seekPromise;
+
+      const { lastSeek, progress } = useTrackPlayer.getState();
+
+      // The event records the seek the user asked for, not player-reported
+      // garbage - previously this recorded a destructive "seek to 0"
+      expect(lastSeek?.from).toBe(150);
+      expect(lastSeek?.to).toBe(140);
+
+      // The store's progress is not poisoned by the dead player's zeros
+      expect(progress.position).toBe(150);
+      expect(progress.duration).toBe(300);
+    });
+  });
+
   describe("setPlaybackRate", () => {
     it("updates rate and emits lastRateChange", async () => {
       const playthrough = await createTestPlaythrough({ position: 50 });

--- a/src/services/position-heartbeat.ts
+++ b/src/services/position-heartbeat.ts
@@ -120,7 +120,15 @@ async function save(): Promise<void> {
   const currentPlaythroughId = Player.getLoadedPlaythrough()?.id;
   if (!currentPlaythroughId) return;
 
-  const { position } = Player.getProgress();
+  const { position, duration } = Player.getProgress();
+
+  // A zeroed duration means progress came from a player that lost its track
+  // (or one that hasn't loaded yet). Never overwrite a good cached position
+  // with that.
+  if (duration <= 0) {
+    log.warn("Skipping position save - progress is invalid (duration is 0)");
+    return;
+  }
 
   // Only save position - rate lives on playthrough, not cache
   await updateStateCache(currentPlaythroughId, position);

--- a/src/services/seek-service.ts
+++ b/src/services/seek-service.ts
@@ -115,8 +115,14 @@ async function applyAccumulatedSeek(source: SeekSourceType) {
   isApplying = true;
   seekTimer = null;
 
+  // A player that lost its track can leave a zeroed duration behind; clamping
+  // against it would turn every seek into a seek to 0. Skip the upper clamp in
+  // that case — the player clamps out-of-range seeks itself.
   const { duration } = Player.getProgress();
-  const positionToApply = Math.max(0, Math.min(targetPosition, duration));
+  const positionToApply =
+    duration > 0
+      ? Math.max(0, Math.min(targetPosition, duration))
+      : Math.max(0, targetPosition);
 
   log.debug(`Applying seek to ${positionToApply.toFixed(1)}`);
 

--- a/src/services/track-player-service.ts
+++ b/src/services/track-player-service.ts
@@ -200,7 +200,11 @@ export async function seekTo(position: number, source: SeekSourceType) {
       playthroughId: playthrough.id,
       playbackRate,
       from: beforeProgress.position,
-      to: progress.position,
+      // Record the position we asked for, not what the player reports. A
+      // stalled or errored streaming player can report a bogus position (0)
+      // after a seek; recording that would rewrite history with a jump the
+      // user never made.
+      to: position,
     },
     ...buildNewProgress(progress),
   });
@@ -656,6 +660,13 @@ async function getProgressWithPercent(): Promise<ProgressWithPercent> {
 
 /**
  * Get progress, waiting up to timeoutMs for a valid duration (> 0).
+ *
+ * If the player never reports a valid duration, it has lost its track — e.g.
+ * it errored out or dropped its item after a streaming network failure — and
+ * everything it reports is zeros. In that case fall back to the store's
+ * last-known progress instead of trusting the player: treating those zeros as
+ * truth is how a bad patch of connectivity used to turn into a recorded "seek
+ * to 0" that destroyed the listening position.
  */
 async function getProgressWaitForDuration(timeoutMs: number = 2000) {
   const startTime = Date.now();
@@ -672,12 +683,13 @@ async function getProgressWaitForDuration(timeoutMs: number = 2000) {
     await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
   }
 
-  // Timeout reached without getting a valid duration
+  // Timeout reached without getting a valid duration: the player's progress
+  // is not trustworthy, so report the last-known progress instead.
+  const lastKnown = useTrackPlayer.getState().progress;
   log.warn(
-    "getProgressWaitForDuration: Timeout reached while waiting for valid duration",
+    `getProgressWaitForDuration: no valid duration from player, falling back to last-known progress (${lastKnown.position.toFixed(1)})`,
   );
-  const progress = await TrackPlayer.getProgress();
-  return progress;
+  return lastKnown;
 }
 
 /**


### PR DESCRIPTION
Fixes the worst-class progress-loss bug: with a streaming (non-downloaded) book loaded and a spotty connection, a seek could be recorded as a jump to 0.0, effectively destroying the listening position.

## Root cause

A streaming player that errors out or drops its item after a network failure reports `{position: 0, duration: 0}`, and the app trusted that unconditionally. The typical chain: the stream stalls → the player errors (stopping the progress interval, so the *store* keeps the real position — which is why the bogus events have a correct `fromPosition`) → the user seeks back a few minutes → `seekRelative` bases itself on the dead player's `0`, computes `0 − 10`, clamps to 0 → `seekTo(0)` records a real-looking seek event `from: <real position>, to: 0` → heartbeat and event replay persist it.

## Fixes (defense in depth)

1. **`getProgressWaitForDuration`** falls back to the store's last-known progress when the player never reports a valid duration, instead of returning the zeros. This fixes the relative-seek base, play/pause position capture, and the 1-second progress interval in one place.
2. **`seekTo`** records the *requested* seek target in the event, not the player-reported landing position — a player that can't confirm a seek can no longer rewrite history with a jump the user never made. (For confirmed seeks these are identical within tolerance.)
3. **`applyAccumulatedSeek`** no longer clamps the target against a zeroed duration, which silently turned *every* seek into a seek to 0.
4. **The position heartbeat** skips saves while store progress is invalid (duration 0), so a good cached position is never overwritten during load or failure windows.

## Tests

- `seek-service`: regression test for the exact reported scenario — jump-back during a stall lands 10s back from the last-known position (previously 0), the player is commanded to the right position, and store progress is unpoisoned.
- `track-player-service`: `getAccurateProgress` falls back to last-known progress when the player reports zeros; `seekTo` on a dead player records the requested `to` and preserves store progress.
- `position-heartbeat` (new suite): saves the current position normally; skips the save and preserves the cached position when progress is invalid.

`npx tsc`, `npm run lint`, and `npm test` (67 suites, 685 tests) all pass.

## Notes

- Existing users who were bitten still have the true position in the bogus seek event's `fromPosition` (user-facing recovery deliberately not included in this PR).
- The native-side claim (player reports zeros after a streaming failure) is inferred, not unit-testable from JS — but every recorded seek-to-0 must pass through `Player.seekTo`, and these guards close every path by which a zero can get in. Worth one manual verify on-device with airplane mode mid-stream.