### PR TITLE
Fix first sync failing on large libraries, and show its progress

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,22 +1,21 @@
 import { useEffect } from "react";
-import { StyleSheet, Text } from "react-native";
+import { StyleSheet } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
-import { SafeAreaView } from "react-native-safe-area-context";
 import * as Sentry from "@sentry/react-native";
 import { useDrizzleStudio } from "expo-drizzle-studio-plugin";
 import { Stack, useNavigationContainerRef } from "expo-router";
 import { DefaultTheme, ThemeProvider } from "expo-router/react-navigation";
 import * as SplashScreen from "expo-splash-screen";
 
-import { Loading } from "@/components/Loading";
+import { ErrorScreen } from "@/components/ErrorScreen";
 import { MeasureScreenHeight } from "@/components/MeasureScreenHeight";
-import { ScreenCentered } from "@/components/ScreenCentered";
+import { SyncProgress } from "@/components/SyncProgress";
 import { getExpoDb } from "@/db/db";
-import { useAppBoot } from "@/services/boot-service";
+import { BootError, BootErrorKind, useAppBoot } from "@/services/boot-service";
 import { useRefreshLibraryDataVersion } from "@/services/data-version-service";
 import { useForegroundSync } from "@/services/sync-service";
-import { useSession } from "@/stores/session";
+import { clearSession, useSession } from "@/stores/session";
 import { useTrackPlayer } from "@/stores/track-player";
 import { Colors, surface } from "@/styles/colors";
 import { StackScreenOptionsProp } from "@/types/router";
@@ -54,9 +53,21 @@ function useSentryNavigationIntegration() {
   return ref;
 }
 
+function bootErrorMessage(error: BootError): string {
+  switch (error.kind) {
+    case BootErrorKind.NETWORK:
+      return "Could not reach your server. Check your connection and your server address, then try again.";
+    case BootErrorKind.SERVER:
+      return "Your server returned an error. Try again, or contact the server admin if it keeps happening.";
+    case BootErrorKind.UNEXPECTED:
+      return "Something went wrong while setting up your library on this device. Try again, or sign out and back in.";
+  }
+}
+
 function RootStackLayout() {
   useSentryNavigationIntegration();
-  const { isReady, migrationError, initialSyncComplete } = useAppBoot();
+  const { isReady, migrationError, initialSyncComplete, bootError, retryBoot } =
+    useAppBoot();
   const isLoggedIn = useSession((state) => !!state.session);
 
   useEffect(() => {
@@ -67,12 +78,10 @@ function RootStackLayout() {
 
   if (migrationError) {
     return (
-      <SafeAreaView>
-        <Text style={styles.text}>
-          The app failed to initialize in an irrecoverable way. Please delete
-          the app's data and start fresh.
-        </Text>
-      </SafeAreaView>
+      <ErrorScreen
+        title="Ambry couldn't start"
+        message="The app failed to initialize in an irrecoverable way. Please delete the app's data and start fresh."
+      />
     );
   }
 
@@ -80,13 +89,21 @@ function RootStackLayout() {
     return null;
   }
 
-  // Show loading spinner if logged in but initial sync not complete
-  if (isLoggedIn && !initialSyncComplete) {
+  // Boot got far enough to know it failed - say so instead of spinning forever
+  if (bootError) {
     return (
-      <ScreenCentered>
-        <Loading />
-      </ScreenCentered>
+      <ErrorScreen
+        title="Ambry couldn't finish setting up"
+        message={bootErrorMessage(bootError)}
+        onRetry={retryBoot}
+        onSignOut={isLoggedIn ? clearSession : undefined}
+      />
     );
+  }
+
+  // Report what the first sync is doing if logged in but not yet finished
+  if (isLoggedIn && !initialSyncComplete) {
+    return <SyncProgress />;
   }
 
   return (
@@ -152,12 +169,6 @@ const Theme = {
 };
 
 const styles = StyleSheet.create({
-  text: {
-    color: Colors.zinc[100],
-    fontSize: 18,
-    paddingHorizontal: 32,
-    paddingTop: 64,
-  },
   modalContent: {
     backgroundColor: surface.overlay,
   },

--- a/src/components/ErrorScreen.tsx
+++ b/src/components/ErrorScreen.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import FontAwesome6 from "@expo/vector-icons/FontAwesome6";
+
+import { IconButton } from "@/components/IconButton";
+import { ScreenCentered } from "@/components/ScreenCentered";
+import { Colors } from "@/styles/colors";
+
+type ErrorScreenProps = {
+  title: string;
+  message: string;
+  /** Shows a "Try again" button. Omit when the failure is not recoverable. */
+  onRetry?: () => void;
+  /** Shows a "Sign out" escape hatch below the retry button. */
+  onSignOut?: () => void;
+};
+
+/**
+ * Full-screen explanation of why the app cannot continue. Anywhere we would
+ * otherwise sit on a spinner indefinitely should render this instead.
+ */
+export function ErrorScreen(props: ErrorScreenProps) {
+  const { title, message, onRetry, onSignOut } = props;
+  const [retrying, setRetrying] = useState(false);
+
+  const retry = () => {
+    setRetrying(true);
+    onRetry?.();
+  };
+
+  return (
+    <ScreenCentered>
+      <View style={styles.container}>
+        <FontAwesome6
+          name="triangle-exclamation"
+          size={48}
+          color={Colors.red[400]}
+          solid
+        />
+        <Text style={styles.title}>{title}</Text>
+        <Text style={styles.message}>{message}</Text>
+
+        {onRetry && (
+          <IconButton
+            style={styles.button}
+            icon={retrying ? "loading" : "rotate-right"}
+            size={20}
+            color={Colors.zinc[900]}
+            onPress={retry}
+          >
+            <Text style={styles.buttonText}>Try again</Text>
+          </IconButton>
+        )}
+
+        {onSignOut && (
+          <TouchableOpacity onPress={onSignOut} accessibilityRole="button">
+            <Text style={styles.signOutText}>Sign out</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    </ScreenCentered>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+    paddingHorizontal: 32,
+    gap: 16,
+  },
+  title: {
+    color: Colors.zinc[100],
+    fontSize: 20,
+    fontWeight: "bold",
+    textAlign: "center",
+  },
+  message: {
+    color: Colors.zinc[400],
+    fontSize: 16,
+    textAlign: "center",
+  },
+  button: {
+    flexDirection: "row-reverse",
+    gap: 8,
+    marginTop: 16,
+    paddingHorizontal: 24,
+    backgroundColor: Colors.lime[400],
+    borderRadius: 999,
+  },
+  buttonText: {
+    color: Colors.zinc[900],
+    fontWeight: "bold",
+  },
+  signOutText: {
+    color: Colors.zinc[400],
+    fontSize: 16,
+    padding: 8,
+  },
+});

--- a/src/components/SyncProgress.tsx
+++ b/src/components/SyncProgress.tsx
@@ -1,0 +1,145 @@
+import { StyleSheet, Text, View } from "react-native";
+
+import { Loading } from "@/components/Loading";
+import { ProgressBar } from "@/components/ProgressBar";
+import { ScreenCentered } from "@/components/ScreenCentered";
+import {
+  SyncStage,
+  SyncTask,
+  TaskProgress,
+  useSyncProgress,
+} from "@/stores/sync-progress";
+import { Colors } from "@/styles/colors";
+
+const TASK_NAMES: Record<SyncTask, string> = {
+  [SyncTask.LIBRARY]: "Library",
+  [SyncTask.EVENTS]: "Listening progress",
+};
+
+/** One line of plain English for what this task is doing right now. */
+function statusText(progress: TaskProgress): string {
+  switch (progress.stage) {
+    case SyncStage.PENDING:
+      return "Waiting…";
+    case SyncStage.DOWNLOADING:
+      return "Downloading…";
+    case SyncStage.SAVING:
+      return progress.detail ? `Saving ${progress.detail}…` : "Saving…";
+    case SyncStage.DONE:
+      return "Done";
+    case SyncStage.FAILED:
+      return "Failed";
+  }
+}
+
+function percentComplete(progress: TaskProgress): number {
+  if (progress.stage === SyncStage.DONE) return 100;
+  if (progress.total === 0) return 0;
+
+  return Math.min(100, (progress.current / progress.total) * 100);
+}
+
+function TaskRow({ task }: { task: SyncTask }) {
+  const progress = useSyncProgress((state) => state.tasks[task]);
+  const showCounts = progress.stage === SyncStage.SAVING && progress.total > 0;
+
+  return (
+    <View style={styles.task}>
+      <View style={styles.taskHeader}>
+        <Text style={styles.taskName}>{TASK_NAMES[task]}</Text>
+        <Text
+          style={[
+            styles.taskStatus,
+            progress.stage === SyncStage.FAILED && styles.taskStatusFailed,
+          ]}
+        >
+          {statusText(progress)}
+        </Text>
+      </View>
+
+      <ProgressBar percent={percentComplete(progress)} />
+
+      {showCounts && (
+        <Text style={styles.counts}>
+          {progress.current.toLocaleString()} of{" "}
+          {progress.total.toLocaleString()}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+/**
+ * Shown while the first sync populates an empty database. Large libraries take
+ * a while, so this names the step in progress rather than spinning silently.
+ */
+export function SyncProgress() {
+  return (
+    <ScreenCentered>
+      <View style={styles.container}>
+        <Loading />
+        <Text style={styles.title}>Setting up your library</Text>
+        <Text style={styles.subtitle}>
+          This only happens once. Large libraries can take a few minutes.
+        </Text>
+
+        <View style={styles.tasks}>
+          <TaskRow task={SyncTask.LIBRARY} />
+          <TaskRow task={SyncTask.EVENTS} />
+        </View>
+      </View>
+    </ScreenCentered>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    paddingHorizontal: 32,
+    gap: 12,
+  },
+  title: {
+    color: Colors.zinc[100],
+    fontSize: 20,
+    fontWeight: "bold",
+    marginTop: 12,
+    textAlign: "center",
+  },
+  subtitle: {
+    color: Colors.zinc[500],
+    fontSize: 14,
+    textAlign: "center",
+  },
+  tasks: {
+    alignSelf: "stretch",
+    marginTop: 24,
+    gap: 24,
+  },
+  task: {
+    alignSelf: "stretch",
+    gap: 6,
+  },
+  taskHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "baseline",
+    gap: 8,
+  },
+  taskName: {
+    color: Colors.zinc[100],
+    fontSize: 16,
+    fontWeight: "bold",
+  },
+  taskStatus: {
+    color: Colors.zinc[400],
+    fontSize: 14,
+  },
+  taskStatusFailed: {
+    color: Colors.red[400],
+  },
+  counts: {
+    color: Colors.zinc[500],
+    fontSize: 12,
+  },
+});

--- a/src/components/__tests__/ErrorScreen.test.tsx
+++ b/src/components/__tests__/ErrorScreen.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { ErrorScreen } from "@/components/ErrorScreen";
+
+describe("ErrorScreen", () => {
+  it("shows the title and message", () => {
+    const { getByText } = render(
+      <ErrorScreen title="Nope" message="Could not reach your server." />,
+    );
+
+    expect(getByText("Nope")).toBeTruthy();
+    expect(getByText("Could not reach your server.")).toBeTruthy();
+  });
+
+  it("omits the actions when no handlers are given", () => {
+    const { queryByText } = render(
+      <ErrorScreen title="Nope" message="Irrecoverable." />,
+    );
+
+    expect(queryByText("Try again")).toBeNull();
+    expect(queryByText("Sign out")).toBeNull();
+  });
+
+  it("retries when the retry button is pressed", () => {
+    const onRetry = jest.fn();
+    const { getByText } = render(
+      <ErrorScreen title="Nope" message="Try later." onRetry={onRetry} />,
+    );
+
+    fireEvent.press(getByText("Try again"));
+
+    expect(onRetry).toHaveBeenCalled();
+  });
+
+  it("signs out when the sign out button is pressed", () => {
+    const onSignOut = jest.fn();
+    const { getByText } = render(
+      <ErrorScreen title="Nope" message="Try later." onSignOut={onSignOut} />,
+    );
+
+    fireEvent.press(getByText("Sign out"));
+
+    expect(onSignOut).toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/SyncProgress.test.tsx
+++ b/src/components/__tests__/SyncProgress.test.tsx
@@ -1,0 +1,73 @@
+import { act, render } from "@testing-library/react-native";
+
+import { SyncProgress } from "@/components/SyncProgress";
+import {
+  beginSyncProgress,
+  resetForTesting,
+  setSyncSaveProgress,
+  setSyncStage,
+  SyncStage,
+  SyncTask,
+} from "@/stores/sync-progress";
+
+describe("SyncProgress", () => {
+  beforeEach(() => {
+    resetForTesting();
+  });
+
+  it("names both halves of the sync", () => {
+    const { getByText } = render(<SyncProgress />);
+
+    expect(getByText("Library")).toBeTruthy();
+    expect(getByText("Listening progress")).toBeTruthy();
+  });
+
+  it("reports the current step and counts while saving", () => {
+    const { getByText } = render(<SyncProgress />);
+
+    act(() => {
+      beginSyncProgress();
+      setSyncSaveProgress(SyncTask.LIBRARY, "books", 1200, 5000);
+    });
+
+    expect(getByText("Saving books…")).toBeTruthy();
+    expect(getByText("1,200 of 5,000")).toBeTruthy();
+  });
+
+  it("shows each task's stage independently", () => {
+    act(() => {
+      beginSyncProgress();
+      setSyncStage(SyncTask.LIBRARY, SyncStage.DOWNLOADING);
+      setSyncStage(SyncTask.EVENTS, SyncStage.DONE);
+    });
+
+    const { getByText } = render(<SyncProgress />);
+    expect(getByText("Downloading…")).toBeTruthy();
+    expect(getByText("Done")).toBeTruthy();
+  });
+
+  it("surfaces a failed task", () => {
+    act(() => {
+      beginSyncProgress();
+      setSyncStage(SyncTask.LIBRARY, SyncStage.FAILED);
+    });
+
+    const { getByText } = render(<SyncProgress />);
+    expect(getByText("Failed")).toBeTruthy();
+  });
+
+  it("fills the bar for a finished task", () => {
+    act(() => {
+      beginSyncProgress();
+      setSyncSaveProgress(SyncTask.LIBRARY, "books", 10, 100);
+      setSyncStage(SyncTask.LIBRARY, SyncStage.DONE);
+    });
+
+    const { getAllByTestId } = render(<SyncProgress />);
+    const libraryFill = getAllByTestId("progress-bar-fill")[0]!;
+
+    expect(libraryFill.props.style).toEqual(
+      expect.arrayContaining([{ width: "100%" }]),
+    );
+  });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -58,7 +58,4 @@ export const DEFAULT_SLEEP_TIMER_ENABLED = false;
 export const DEFAULT_SLEEP_TIMER_MOTION_DETECTION_ENABLED = false;
 export const DEFAULT_PREFERRED_PLAYBACK_RATE = 1.0;
 
-export const FOREGROUND_SYNC_INTERVAL = 15 * 60 * 1000; // 15 minutesexport const CHUNK_SIZE = 10000;
-
-// Number of events to process in a single batch when doing bulk inserts/updates.
-export const EVENT_INSERT_CHUNK_SIZE = 10_000;
+export const FOREGROUND_SYNC_INTERVAL = 15 * 60 * 1000; // 15 minutes

--- a/src/db/__tests__/sync.test.ts
+++ b/src/db/__tests__/sync.test.ts
@@ -949,6 +949,60 @@ describe("sync", () => {
         );
       });
     });
+
+    // =========================================================================
+    // Large libraries
+    // =========================================================================
+
+    describe("large libraries", () => {
+      // A multi-row insert binds one parameter per column per row, and SQLite
+      // caps a statement at SQLITE_MAX_VARIABLE_NUMBER (32766) parameters. A
+      // first sync sends the whole library at once, so these batches have to be
+      // split up or the insert fails with "too many SQL variables".
+
+      it("inserts more media than fit in a single statement", async () => {
+        const db = getDb();
+        const book = createLibraryBook({ id: "book-1" });
+        // media is the widest table (21 columns), so it overflows first
+        const media = Array.from({ length: 2000 }, (_, i) =>
+          createLibraryMedia({ id: `media-${i}`, bookId: "book-1" }),
+        );
+
+        mockGraphQL(
+          mockFetch,
+          graphqlSuccess({
+            ...emptyLibraryChanges(),
+            booksChangedSince: [book],
+            mediaChangedSince: media,
+          }),
+        );
+
+        await syncLibrary(session);
+
+        const allMedia = await db.query.media.findMany();
+        expect(allMedia).toHaveLength(2000);
+      });
+
+      it("inserts more people than fit in a single statement", async () => {
+        const db = getDb();
+        const people = Array.from({ length: 5000 }, (_, i) =>
+          createLibraryPerson({ id: `person-${i}` }),
+        );
+
+        mockGraphQL(
+          mockFetch,
+          graphqlSuccess({
+            ...emptyLibraryChanges(),
+            peopleChangedSince: people,
+          }),
+        );
+
+        await syncLibrary(session);
+
+        const allPeople = await db.query.people.findMany();
+        expect(allPeople).toHaveLength(5000);
+      });
+    });
   });
 
   // ===========================================================================

--- a/src/db/chunk.ts
+++ b/src/db/chunk.ts
@@ -1,0 +1,40 @@
+import { getTableColumns } from "drizzle-orm";
+import type { SQLiteTable } from "drizzle-orm/sqlite-core";
+
+/**
+ * SQLite refuses to prepare a statement that binds more than
+ * SQLITE_MAX_VARIABLE_NUMBER parameters, failing with "too many SQL variables".
+ * Both expo-sqlite and better-sqlite3 build with the SQLite 3.32+ default of
+ * 32766; we stay well under it.
+ */
+const MAX_SQL_VARIABLES = 30_000;
+
+/**
+ * Split rows into batches that can each be inserted into `table` in a single
+ * statement. A multi-row insert binds one parameter per column per row, so a
+ * first sync - which sends the entire library at once - overflows the limit
+ * without this.
+ */
+export function chunkRowsForInsert<T>(table: SQLiteTable, rows: T[]): T[][] {
+  const columnCount = Object.keys(getTableColumns(table)).length;
+
+  return chunk(rows, Math.max(1, Math.floor(MAX_SQL_VARIABLES / columnCount)));
+}
+
+/**
+ * Split values that are bound one parameter each - the id list of an `inArray`
+ * filter, for example - into batches that stay under the limit.
+ */
+export function chunkBoundValues<T>(values: T[]): T[][] {
+  return chunk(values, MAX_SQL_VARIABLES);
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+
+  return chunks;
+}

--- a/src/db/playthrough-reducer.ts
+++ b/src/db/playthrough-reducer.ts
@@ -275,6 +275,7 @@ export async function rebuildPlaythroughs(
   session: Session,
   tx: Database,
   refreshedAt: Date,
+  onRebuilt?: (count: number) => void,
 ): Promise<void> {
   if (playthroughIds.length === 0) return;
 
@@ -282,5 +283,6 @@ export async function rebuildPlaythroughs(
 
   for (const playthroughId of playthroughIds) {
     await rebuildPlaythrough(playthroughId, session, tx, refreshedAt);
+    onRebuilt?.(1);
   }
 }

--- a/src/db/playthroughs.ts
+++ b/src/db/playthroughs.ts
@@ -1,6 +1,6 @@
 import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 
-import { EVENT_INSERT_CHUNK_SIZE } from "@/constants";
+import { chunkBoundValues, chunkRowsForInsert } from "@/db/chunk";
 import { Database, getDb } from "@/db/db";
 import { rebuildPlaythrough } from "@/db/playthrough-reducer";
 import * as schema from "@/db/schema";
@@ -553,10 +553,12 @@ export async function markEventsSynced(
 ): Promise<void> {
   if (eventIds.length === 0) return;
 
-  await db
-    .update(schema.playbackEvents)
-    .set({ syncedAt })
-    .where(inArray(schema.playbackEvents.id, eventIds));
+  for (const ids of chunkBoundValues(eventIds)) {
+    await db
+      .update(schema.playbackEvents)
+      .set({ syncedAt })
+      .where(inArray(schema.playbackEvents.id, ids));
+  }
 }
 
 /**
@@ -566,10 +568,9 @@ export async function markEventsSynced(
 export async function upsertPlaybackEvents(
   events: PlaybackEventInsert[],
   db: Database = getDb(),
+  onWritten?: (rows: number) => void,
 ): Promise<void> {
-  for (let i = 0; i < events.length; i += EVENT_INSERT_CHUNK_SIZE) {
-    const chunk = events.slice(i, i + EVENT_INSERT_CHUNK_SIZE);
-
+  for (const chunk of chunkRowsForInsert(schema.playbackEvents, events)) {
     await db
       .insert(schema.playbackEvents)
       .values(chunk)
@@ -589,6 +590,8 @@ export async function upsertPlaybackEvents(
           syncedAt: sql`excluded.synced_at`,
         },
       });
+
+    onWritten?.(chunk.length);
   }
 }
 

--- a/src/db/sync.ts
+++ b/src/db/sync.ts
@@ -1,5 +1,6 @@
 import { and, eq, inArray, sql } from "drizzle-orm";
 
+import { chunkBoundValues, chunkRowsForInsert } from "@/db/chunk";
 import { getDb } from "@/db/db";
 import { rebuildPlaythroughs } from "@/db/playthrough-reducer";
 import {
@@ -161,6 +162,39 @@ export interface ApplyLibraryChangesResult {
 }
 
 /**
+ * Called as rows are written so callers can show progress. `detail` names what
+ * is being written right now ("books"), and the counts are across everything
+ * the call will write, not just the current step.
+ */
+export type ApplyProgressCallback = (progress: {
+  detail: string;
+  current: number;
+  total: number;
+}) => void;
+
+/**
+ * Tracks how far through a bulk write we are. `step` announces a new kind of
+ * row; `wrote` records rows that have landed.
+ */
+function progressReporter(total: number, onProgress?: ApplyProgressCallback) {
+  let detail = "";
+  let current = 0;
+
+  const emit = () => onProgress?.({ detail, current, total });
+
+  return {
+    step(nextDetail: string) {
+      detail = nextDetail;
+      emit();
+    },
+    wrote(rows: number) {
+      current += rows;
+      emit();
+    },
+  };
+}
+
+/**
  * Apply library changes from the server to the local database.
  * Returns the new data version timestamp if there were changes.
  */
@@ -168,6 +202,7 @@ export async function applyLibraryChanges(
   session: Session,
   changes: LibraryChangesInput,
   previousSyncInfo: LibrarySyncInfo,
+  onProgress?: ApplyProgressCallback,
 ): Promise<ApplyLibraryChangesResult> {
   log.info("applying library changes...");
 
@@ -327,164 +362,224 @@ export async function applyLibraryChanges(
       ? serverTime
       : previousSyncInfo.libraryDataVersion;
 
+  // Deletions are excluded: they are a single statement per type and would make
+  // the bar jump rather than describe the work that actually takes time.
+  const progress = progressReporter(
+    peopleValues.length +
+      authorValues.length +
+      narratorValues.length +
+      booksValues.length +
+      bookAuthorsValues.length +
+      seriesValues.length +
+      seriesBooksValues.length +
+      mediaValues.length +
+      mediaNarratorsValues.length,
+    onProgress,
+  );
+
   await getDb().transaction(async (tx) => {
     if (peopleValues.length !== 0) {
       log.debug("inserting", peopleValues.length, "people...");
-      await tx
-        .insert(schema.people)
-        .values(peopleValues)
-        .onConflictDoUpdate({
-          target: [schema.people.url, schema.people.id],
-          set: {
-            name: sql`excluded.name`,
-            description: sql`excluded.description`,
-            thumbnails: sql`excluded.thumbnails`,
-            updatedAt: sql`excluded.updated_at`,
-          },
-        });
+      progress.step("people");
+      for (const rows of chunkRowsForInsert(schema.people, peopleValues)) {
+        await tx
+          .insert(schema.people)
+          .values(rows)
+          .onConflictDoUpdate({
+            target: [schema.people.url, schema.people.id],
+            set: {
+              name: sql`excluded.name`,
+              description: sql`excluded.description`,
+              thumbnails: sql`excluded.thumbnails`,
+              updatedAt: sql`excluded.updated_at`,
+            },
+          });
+        progress.wrote(rows.length);
+      }
       log.debug("people inserted");
     }
 
     if (authorValues.length !== 0) {
       log.debug("inserting", authorValues.length, "authors...");
-      await tx
-        .insert(schema.authors)
-        .values(authorValues)
-        .onConflictDoUpdate({
-          target: [schema.authors.url, schema.authors.id],
-          set: {
-            personId: sql`excluded.person_id`,
-            name: sql`excluded.name`,
-            updatedAt: sql`excluded.updated_at`,
-          },
-        });
+      progress.step("authors");
+      for (const rows of chunkRowsForInsert(schema.authors, authorValues)) {
+        await tx
+          .insert(schema.authors)
+          .values(rows)
+          .onConflictDoUpdate({
+            target: [schema.authors.url, schema.authors.id],
+            set: {
+              personId: sql`excluded.person_id`,
+              name: sql`excluded.name`,
+              updatedAt: sql`excluded.updated_at`,
+            },
+          });
+        progress.wrote(rows.length);
+      }
       log.debug("authors inserted");
     }
 
     if (narratorValues.length !== 0) {
       log.debug(`inserting ${narratorValues.length} narrators...`);
-      await tx
-        .insert(schema.narrators)
-        .values(narratorValues)
-        .onConflictDoUpdate({
-          target: [schema.narrators.url, schema.narrators.id],
-          set: {
-            personId: sql`excluded.person_id`,
-            name: sql`excluded.name`,
-            updatedAt: sql`excluded.updated_at`,
-          },
-        });
+      progress.step("narrators");
+      for (const rows of chunkRowsForInsert(schema.narrators, narratorValues)) {
+        await tx
+          .insert(schema.narrators)
+          .values(rows)
+          .onConflictDoUpdate({
+            target: [schema.narrators.url, schema.narrators.id],
+            set: {
+              personId: sql`excluded.person_id`,
+              name: sql`excluded.name`,
+              updatedAt: sql`excluded.updated_at`,
+            },
+          });
+        progress.wrote(rows.length);
+      }
       log.debug("narrators inserted");
     }
 
     if (booksValues.length !== 0) {
       log.debug("inserting", booksValues.length, "books...");
-      await tx
-        .insert(schema.books)
-        .values(booksValues)
-        .onConflictDoUpdate({
-          target: [schema.books.url, schema.books.id],
-          set: {
-            title: sql`excluded.title`,
-            published: sql`excluded.published`,
-            publishedFormat: sql`excluded.published_format`,
-            updatedAt: sql`excluded.updated_at`,
-          },
-        });
+      progress.step("books");
+      for (const rows of chunkRowsForInsert(schema.books, booksValues)) {
+        await tx
+          .insert(schema.books)
+          .values(rows)
+          .onConflictDoUpdate({
+            target: [schema.books.url, schema.books.id],
+            set: {
+              title: sql`excluded.title`,
+              published: sql`excluded.published`,
+              publishedFormat: sql`excluded.published_format`,
+              updatedAt: sql`excluded.updated_at`,
+            },
+          });
+        progress.wrote(rows.length);
+      }
       log.debug("books inserted");
     }
 
     if (bookAuthorsValues.length !== 0) {
       log.debug(`inserting ${bookAuthorsValues.length} book authors...`);
-      await tx
-        .insert(schema.bookAuthors)
-        .values(bookAuthorsValues)
-        .onConflictDoUpdate({
-          target: [schema.bookAuthors.url, schema.bookAuthors.id],
-          set: {
-            bookId: sql`excluded.book_id`,
-            authorId: sql`excluded.author_id`,
-            updatedAt: sql`excluded.updated_at`,
-          },
-        });
+      progress.step("book authors");
+      for (const rows of chunkRowsForInsert(
+        schema.bookAuthors,
+        bookAuthorsValues,
+      )) {
+        await tx
+          .insert(schema.bookAuthors)
+          .values(rows)
+          .onConflictDoUpdate({
+            target: [schema.bookAuthors.url, schema.bookAuthors.id],
+            set: {
+              bookId: sql`excluded.book_id`,
+              authorId: sql`excluded.author_id`,
+              updatedAt: sql`excluded.updated_at`,
+            },
+          });
+        progress.wrote(rows.length);
+      }
       log.debug("book authors inserted");
     }
 
     if (seriesValues.length !== 0) {
       log.debug("inserting", seriesValues.length, "series...");
-      await tx
-        .insert(schema.series)
-        .values(seriesValues)
-        .onConflictDoUpdate({
-          target: [schema.series.url, schema.series.id],
-          set: {
-            name: sql`excluded.name`,
-            updatedAt: sql`excluded.updated_at`,
-          },
-        });
+      progress.step("series");
+      for (const rows of chunkRowsForInsert(schema.series, seriesValues)) {
+        await tx
+          .insert(schema.series)
+          .values(rows)
+          .onConflictDoUpdate({
+            target: [schema.series.url, schema.series.id],
+            set: {
+              name: sql`excluded.name`,
+              updatedAt: sql`excluded.updated_at`,
+            },
+          });
+        progress.wrote(rows.length);
+      }
       log.debug("series inserted");
     }
 
     if (seriesBooksValues.length !== 0) {
       log.debug(`inserting ${seriesBooksValues.length} series books...`);
-      await tx
-        .insert(schema.seriesBooks)
-        .values(seriesBooksValues)
-        .onConflictDoUpdate({
-          target: [schema.seriesBooks.url, schema.seriesBooks.id],
-          set: {
-            bookId: sql`excluded.book_id`,
-            seriesId: sql`excluded.series_id`,
-            bookNumber: sql`excluded.book_number`,
-            updatedAt: sql`excluded.updated_at`,
-          },
-        });
+      progress.step("series books");
+      for (const rows of chunkRowsForInsert(
+        schema.seriesBooks,
+        seriesBooksValues,
+      )) {
+        await tx
+          .insert(schema.seriesBooks)
+          .values(rows)
+          .onConflictDoUpdate({
+            target: [schema.seriesBooks.url, schema.seriesBooks.id],
+            set: {
+              bookId: sql`excluded.book_id`,
+              seriesId: sql`excluded.series_id`,
+              bookNumber: sql`excluded.book_number`,
+              updatedAt: sql`excluded.updated_at`,
+            },
+          });
+        progress.wrote(rows.length);
+      }
       log.debug("series books inserted");
     }
 
     if (mediaValues.length !== 0) {
       log.debug("inserting", mediaValues.length, "media...");
-      await tx
-        .insert(schema.media)
-        .values(mediaValues)
-        .onConflictDoUpdate({
-          target: [schema.media.url, schema.media.id],
-          set: {
-            status: sql`excluded.status`,
-            bookId: sql`excluded.book_id`,
-            duration: sql`excluded.duration`,
-            published: sql`excluded.published`,
-            publishedFormat: sql`excluded.published_format`,
-            publisher: sql`excluded.publisher`,
-            notes: sql`excluded.notes`,
-            description: sql`excluded.description`,
-            thumbnails: sql`excluded.thumbnails`,
-            abridged: sql`excluded.abridged`,
-            fullCast: sql`excluded.full_cast`,
-            chapters: sql`excluded.chapters`,
-            supplementalFiles: sql`excluded.supplemental_files`,
-            mp4Path: sql`excluded.mp4_path`,
-            mpdPath: sql`excluded.mpd_path`,
-            hlsPath: sql`excluded.hls_path`,
-            updatedAt: sql`excluded.updated_at`,
-          },
-        });
+      progress.step("media");
+      for (const rows of chunkRowsForInsert(schema.media, mediaValues)) {
+        await tx
+          .insert(schema.media)
+          .values(rows)
+          .onConflictDoUpdate({
+            target: [schema.media.url, schema.media.id],
+            set: {
+              status: sql`excluded.status`,
+              bookId: sql`excluded.book_id`,
+              duration: sql`excluded.duration`,
+              published: sql`excluded.published`,
+              publishedFormat: sql`excluded.published_format`,
+              publisher: sql`excluded.publisher`,
+              notes: sql`excluded.notes`,
+              description: sql`excluded.description`,
+              thumbnails: sql`excluded.thumbnails`,
+              abridged: sql`excluded.abridged`,
+              fullCast: sql`excluded.full_cast`,
+              chapters: sql`excluded.chapters`,
+              supplementalFiles: sql`excluded.supplemental_files`,
+              mp4Path: sql`excluded.mp4_path`,
+              mpdPath: sql`excluded.mpd_path`,
+              hlsPath: sql`excluded.hls_path`,
+              updatedAt: sql`excluded.updated_at`,
+            },
+          });
+        progress.wrote(rows.length);
+      }
       log.debug("media inserted");
     }
 
     if (mediaNarratorsValues.length !== 0) {
       log.debug(`inserting ${mediaNarratorsValues.length} media narrators...`);
-      await tx
-        .insert(schema.mediaNarrators)
-        .values(mediaNarratorsValues)
-        .onConflictDoUpdate({
-          target: [schema.mediaNarrators.url, schema.mediaNarrators.id],
-          set: {
-            mediaId: sql`excluded.media_id`,
-            narratorId: sql`excluded.narrator_id`,
-            updatedAt: sql`excluded.updated_at`,
-          },
-        });
+      progress.step("narrations");
+      for (const rows of chunkRowsForInsert(
+        schema.mediaNarrators,
+        mediaNarratorsValues,
+      )) {
+        await tx
+          .insert(schema.mediaNarrators)
+          .values(rows)
+          .onConflictDoUpdate({
+            target: [schema.mediaNarrators.url, schema.mediaNarrators.id],
+            set: {
+              mediaId: sql`excluded.media_id`,
+              narratorId: sql`excluded.narrator_id`,
+              updatedAt: sql`excluded.updated_at`,
+            },
+          });
+        progress.wrote(rows.length);
+      }
       log.debug("media narrators inserted");
     }
 
@@ -493,9 +588,9 @@ export async function applyLibraryChanges(
         log.debug(
           `deleting ${deletionIds[deletionType].length} ${deletionType}`,
         );
-        await tx
-          .delete(table)
-          .where(inArray(table.id, deletionIds[deletionType]));
+        for (const ids of chunkBoundValues(deletionIds[deletionType])) {
+          await tx.delete(table).where(inArray(table.id, ids));
+        }
         log.debug(`deleted ${deletionType}`);
       }
     }
@@ -590,6 +685,7 @@ export async function applyEventSyncResult(
   session: Session,
   syncResult: EventSyncResultInput,
   sentEventIds: string[],
+  onProgress?: ApplyProgressCallback,
 ): Promise<void> {
   const serverTime = new Date(syncResult.serverTime);
 
@@ -617,6 +713,13 @@ export async function applyEventSyncResult(
     },
   );
 
+  // Rebuilding walks each affected playthrough one at a time, so it is counted
+  // alongside the events themselves rather than left as a silent tail
+  const progress = progressReporter(
+    eventsPayload.length + affectedPlaythroughIds.size,
+    onProgress,
+  );
+
   await getDb().transaction(async (tx) => {
     // Mark sent events as synced
     if (sentEventIds.length > 0) {
@@ -625,16 +728,23 @@ export async function applyEventSyncResult(
 
     // Upsert received events from server
     if (syncResult.events.length > 0) {
-      await upsertPlaybackEvents(eventsPayload, tx);
+      progress.step("listening history");
+      await upsertPlaybackEvents(eventsPayload, tx, (rows) =>
+        progress.wrote(rows),
+      );
     }
 
     // Rebuild affected playthroughs from their events
     // This ensures client and server have identical derived state
+    if (affectedPlaythroughIds.size > 0) {
+      progress.step("playback positions");
+    }
     await rebuildPlaythroughs(
       Array.from(affectedPlaythroughIds),
       session,
       tx,
       serverTime,
+      (count) => progress.wrote(count),
     );
 
     // Update server profile with new sync time

--- a/src/services/__tests__/background-sync-service.test.ts
+++ b/src/services/__tests__/background-sync-service.test.ts
@@ -154,12 +154,13 @@ describe("background-sync-service", () => {
 
       // Mock GraphQL responses for library changes and sync events. This is
       // done this way because both syncs happen concurrently so we need to
-      // differentiate based on operation name.
+      // differentiate based on operation name. The client does not send an
+      // `operationName` field, so match on the query document itself.
       mockFetch.mockImplementation(
         async (input: RequestInfo | URL, init?: RequestInit) => {
           const body = JSON.parse(init?.body as string);
 
-          if (body.operationName === "LibraryChangesSince") {
+          if (body.query?.includes("query LibraryChangesSince")) {
             return new Response(
               JSON.stringify({ data: emptyLibraryChanges(serverTime) }),
               {
@@ -169,10 +170,10 @@ describe("background-sync-service", () => {
             );
           }
 
-          if (body.operationName === "SyncEvents") {
+          if (body.query?.includes("mutation SyncEvents")) {
             return new Response(
               JSON.stringify({
-                data: { syncEvents: emptySyncEventsResult(serverTime) },
+                data: emptySyncEventsResult(serverTime),
               }),
               {
                 status: 200,
@@ -203,7 +204,7 @@ describe("background-sync-service", () => {
       );
     });
 
-    it("returns failed when sync throws an error", async () => {
+    it("returns failed when sync fails", async () => {
       useSession.setState({ session });
 
       // Mock network error

--- a/src/services/__tests__/boot-service.test.ts
+++ b/src/services/__tests__/boot-service.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the app boot sequence.
+ *
+ * Uses Detroit-style testing: the real sync service, GraphQL API, stores and
+ * database code runs. Only boundaries are mocked - `fetch`, the native modules
+ * faked in jest-setup, and `useDatabaseMigrations`, which drives drizzle's
+ * expo-sqlite migrator against a native database the test db does not have.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+
+import { BootErrorKind, useAppBoot } from "@/services/boot-service";
+import { resetForTesting as resetSleepTimerService } from "@/services/sleep-timer-service";
+import { resetForTesting as resetTrackPlayerService } from "@/services/track-player-service";
+import { resetForTesting as resetDataVersionStore } from "@/stores/data-version";
+import {
+  resetForTesting as resetDeviceStore,
+  useDevice,
+} from "@/stores/device";
+import {
+  resetForTesting as resetSessionStore,
+  useSession,
+} from "@/stores/session";
+import { setupTestDatabase } from "@test/db-test-utils";
+import { DEFAULT_TEST_SESSION } from "@test/factories";
+import {
+  graphqlUnauthorized,
+  installFetchMock,
+  mockGraphQL,
+  mockNetworkError,
+} from "@test/fetch-mock";
+import {
+  createLibraryPerson,
+  emptyLibraryChanges,
+  emptySyncEventsResult,
+} from "@test/sync-fixtures";
+
+jest.mock("@/services/db-service", () => ({
+  useDatabaseMigrations: () => ({ success: true, error: undefined }),
+  performWalCheckpoint: jest.fn(),
+}));
+
+const { getDb } = setupTestDatabase();
+
+const session = DEFAULT_TEST_SESSION;
+
+/** Answer both halves of a sync successfully, with the given library payload. */
+function mockSuccessfulSync(
+  mockFetch: ReturnType<typeof installFetchMock>,
+  serverTime: string,
+  changes: Partial<ReturnType<typeof emptyLibraryChanges>> = {},
+) {
+  mockFetch.mockImplementation(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string);
+      const data = body.query?.includes("query LibraryChangesSince")
+        ? { ...emptyLibraryChanges(serverTime), ...changes }
+        : emptySyncEventsResult(serverTime);
+
+      return new Response(JSON.stringify({ data }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  );
+}
+
+describe("boot-service", () => {
+  let mockFetch: ReturnType<typeof installFetchMock>;
+
+  beforeEach(() => {
+    mockFetch = installFetchMock();
+
+    resetSessionStore();
+    resetDataVersionStore();
+    resetDeviceStore();
+
+    useSession.setState({ session });
+    useDevice.setState({
+      initialized: true,
+      deviceInfo: {
+        id: "test-device-id",
+        type: "android" as const,
+        brand: "TestBrand",
+        modelName: "TestModel",
+        osName: "Android",
+        osVersion: "14",
+        appId: "app.ambry.mobile.dev",
+        appVersion: "1.0.0",
+        appBuild: "1",
+      },
+    });
+  });
+
+  afterEach(() => {
+    resetTrackPlayerService();
+    resetSleepTimerService();
+  });
+
+  it("finishes boot when the initial sync succeeds", async () => {
+    const serverTime = "2024-01-15T10:00:00.000Z";
+    mockSuccessfulSync(mockFetch, serverTime);
+
+    const { result } = renderHook(() => useAppBoot());
+
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+    expect(result.current.initialSyncComplete).toBe(true);
+    expect(result.current.bootError).toBeNull();
+  });
+
+  it("reports an error rather than waiting forever when the initial sync fails", async () => {
+    mockNetworkError(mockFetch);
+    mockNetworkError(mockFetch);
+
+    const { result } = renderHook(() => useAppBoot());
+
+    await waitFor(() => expect(result.current.bootError).not.toBeNull());
+    expect(result.current.bootError?.kind).toBe(BootErrorKind.NETWORK);
+    // isReady has to flip too, or the app sits on the splash screen instead of
+    // rendering the error
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.initialSyncComplete).toBe(false);
+  });
+
+  it("actually re-runs the outstanding initial sync when retried", async () => {
+    const db = getDb();
+
+    mockNetworkError(mockFetch);
+    mockNetworkError(mockFetch);
+
+    const { result } = renderHook(() => useAppBoot());
+    await waitFor(() => expect(result.current.bootError).not.toBeNull());
+
+    // The library never synced, so nothing was stored
+    expect(await db.query.people.findMany()).toHaveLength(0);
+
+    mockSuccessfulSync(mockFetch, "2024-01-15T10:00:00.000Z", {
+      peopleChangedSince: [createLibraryPerson({ id: "person-1" })],
+    });
+
+    act(() => result.current.retryBoot());
+
+    await waitFor(() => expect(result.current.initialSyncComplete).toBe(true));
+    expect(result.current.bootError).toBeNull();
+
+    // The retry has to perform the sync it skipped, not just declare success
+    expect(await db.query.people.findMany()).toHaveLength(1);
+  });
+
+  it("does not show an error when the server rejects the session", async () => {
+    mockGraphQL(mockFetch, graphqlUnauthorized());
+    mockGraphQL(mockFetch, graphqlUnauthorized());
+
+    const { result } = renderHook(() => useAppBoot());
+
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+    // The cleared session sends the user back to sign-in on its own
+    expect(useSession.getState().session).toBeNull();
+    expect(result.current.bootError).toBeNull();
+  });
+});

--- a/src/services/__tests__/sync-hooks.test.ts
+++ b/src/services/__tests__/sync-hooks.test.ts
@@ -99,7 +99,7 @@ describe("usePullToRefresh", () => {
     );
     const playthroughResponse = new Response(
       JSON.stringify({
-        data: { syncEvents: emptySyncEventsResult(serverTime) },
+        data: emptySyncEventsResult(serverTime),
       }),
       { status: 200, headers: { "Content-Type": "application/json" } },
     );
@@ -120,10 +120,7 @@ describe("usePullToRefresh", () => {
 
     // Mock successful responses for both sync operations
     mockGraphQL(mockFetch, graphqlSuccess(emptyLibraryChanges(serverTime)));
-    mockGraphQL(
-      mockFetch,
-      graphqlSuccess({ syncEvents: emptySyncEventsResult(serverTime) }),
-    );
+    mockGraphQL(mockFetch, graphqlSuccess(emptySyncEventsResult(serverTime)));
 
     const { result } = renderHook(() => usePullToRefresh(DEFAULT_TEST_SESSION));
 

--- a/src/services/__tests__/sync-service.test.ts
+++ b/src/services/__tests__/sync-service.test.ts
@@ -8,7 +8,13 @@
  * The real sync service, GraphQL API, and database code runs.
  */
 
-import { sync, syncLibrary, syncPlaybackEvents } from "@/services/sync-service";
+import {
+  firstSyncError,
+  sync,
+  SyncErrorCode,
+  syncLibrary,
+  syncPlaybackEvents,
+} from "@/services/sync-service";
 import {
   resetForTesting as resetDataVersionStore,
   useDataVersion,
@@ -21,6 +27,12 @@ import {
   resetForTesting as resetSessionStore,
   useSession,
 } from "@/stores/session";
+import {
+  resetForTesting as resetSyncProgressStore,
+  SyncStage,
+  SyncTask,
+  useSyncProgress,
+} from "@/stores/sync-progress";
 import { setupTestDatabase } from "@test/db-test-utils";
 import { DEFAULT_TEST_SESSION } from "@test/factories";
 import {
@@ -29,8 +41,11 @@ import {
   graphqlUnauthorized,
   installFetchMock,
   mockGraphQL,
+  mockNetworkError,
 } from "@test/fetch-mock";
 import {
+  createLibraryBook,
+  createLibraryPerson,
   emptyLibraryChanges,
   emptySyncEventsResult,
   resetSyncFixtureIdCounter,
@@ -52,6 +67,7 @@ function setupStores() {
   resetSessionStore();
   resetDataVersionStore();
   resetDeviceStore();
+  resetSyncProgressStore();
 
   useSession.setState({ session });
   useDataVersion.setState({
@@ -94,14 +110,119 @@ describe("sync-service", () => {
       const serverTime = "2024-01-15T10:00:00.000Z";
 
       mockGraphQL(mockFetch, graphqlSuccess(emptyLibraryChanges(serverTime)));
-      mockGraphQL(
-        mockFetch,
-        graphqlSuccess({ syncProgress: emptySyncEventsResult(serverTime) }),
-      );
+      mockGraphQL(mockFetch, graphqlSuccess(emptySyncEventsResult(serverTime)));
 
       const result = await sync(session);
 
-      expect(result).toEqual([undefined, undefined]);
+      expect(result.library.success).toBe(true);
+      expect(result.events.success).toBe(true);
+      expect(firstSyncError(result)).toBeNull();
+    });
+
+    it("reports a network failure instead of throwing", async () => {
+      mockNetworkError(mockFetch);
+      mockNetworkError(mockFetch);
+
+      const result = await sync(session);
+
+      expect(firstSyncError(result)?.code).toBe(SyncErrorCode.NETWORK);
+    });
+
+    it("reports a database failure instead of throwing", async () => {
+      const serverTime = "2024-01-15T10:00:00.000Z";
+
+      // A library payload the local schema cannot store: `id` is NOT NULL, so
+      // applying these changes throws inside the transaction.
+      mockGraphQL(
+        mockFetch,
+        graphqlSuccess({
+          ...emptyLibraryChanges(serverTime),
+          peopleChangedSince: [
+            { ...createLibraryPerson(), id: null as unknown as string },
+          ],
+        }),
+      );
+      mockGraphQL(mockFetch, graphqlSuccess(emptySyncEventsResult(serverTime)));
+
+      const result = await sync(session);
+
+      expect(result.library.success).toBe(false);
+      expect(firstSyncError(result)?.code).toBe(SyncErrorCode.UNEXPECTED);
+    });
+  });
+
+  // ===========================================================================
+  // Progress reporting
+  // ===========================================================================
+
+  describe("sync progress", () => {
+    it("names each step and counts rows as the library is written", async () => {
+      const serverTime = "2024-01-15T10:00:00.000Z";
+      const people = Array.from({ length: 3 }, (_, i) =>
+        createLibraryPerson({ id: `person-${i}` }),
+      );
+      const books = Array.from({ length: 2 }, (_, i) =>
+        createLibraryBook({ id: `book-${i}` }),
+      );
+
+      // Record every report rather than the end state, since the point is that
+      // progress is visible *during* the write
+      const reports: { detail: string; current: number; total: number }[] = [];
+      const unsubscribe = useSyncProgress.subscribe((state) => {
+        const { stage, detail, current, total } = state.tasks[SyncTask.LIBRARY];
+        if (stage === SyncStage.SAVING && detail) {
+          reports.push({ detail, current, total });
+        }
+      });
+
+      mockGraphQL(
+        mockFetch,
+        graphqlSuccess({
+          ...emptyLibraryChanges(serverTime),
+          peopleChangedSince: people,
+          booksChangedSince: books,
+        }),
+      );
+      mockGraphQL(mockFetch, graphqlSuccess(emptySyncEventsResult(serverTime)));
+
+      await syncLibrary(session);
+      unsubscribe();
+
+      expect(reports.map((r) => r.detail)).toEqual([
+        "people",
+        "people",
+        "books",
+        "books",
+      ]);
+      // Every report counts against the whole write, not just the current step
+      expect(reports.every((r) => r.total === 5)).toBe(true);
+      expect(reports.map((r) => r.current)).toEqual([0, 3, 3, 5]);
+    });
+
+    it("moves the library task through downloading to done", async () => {
+      const serverTime = "2024-01-15T10:00:00.000Z";
+      const stages: SyncStage[] = [];
+      const unsubscribe = useSyncProgress.subscribe((state) => {
+        const { stage } = state.tasks[SyncTask.LIBRARY];
+        if (stages[stages.length - 1] !== stage) stages.push(stage);
+      });
+
+      mockGraphQL(mockFetch, graphqlSuccess(emptyLibraryChanges(serverTime)));
+
+      await syncLibrary(session);
+      unsubscribe();
+
+      expect(stages).toEqual([SyncStage.DOWNLOADING, SyncStage.DONE]);
+    });
+
+    it("marks the task failed when the sync fails", async () => {
+      mockNetworkError(mockFetch);
+
+      await syncLibrary(session);
+
+      expect(useSyncProgress.getState().tasks[SyncTask.LIBRARY].stage).toBe(
+        SyncStage.FAILED,
+      );
     });
   });
 

--- a/src/services/background-sync-service.ts
+++ b/src/services/background-sync-service.ts
@@ -5,7 +5,7 @@ import { getExpoDb } from "@/db/db";
 import { useSession } from "@/stores/session";
 import { logBase } from "@/utils/logger";
 
-import { sync } from "./sync-service";
+import { firstSyncError, sync } from "./sync-service";
 
 const log = logBase.extend("background-sync");
 
@@ -21,7 +21,13 @@ TaskManager.defineTask(BACKGROUND_SYNC_TASK_NAME, async () => {
   }
 
   try {
-    await sync(session);
+    const error = firstSyncError(await sync(session));
+
+    if (error) {
+      // Report the failure so the OS backs off and reschedules us
+      log.error("failed:", error.code);
+      return BackgroundTask.BackgroundTaskResult.Failed;
+    }
 
     log.info("performing WAL checkpoint");
     getExpoDb().execSync("PRAGMA wal_checkpoint(PASSIVE);");

--- a/src/services/boot-service.ts
+++ b/src/services/boot-service.ts
@@ -5,7 +5,8 @@
  * and initial sync.
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import * as Sentry from "@sentry/react-native";
 
 import { registerBackgroundSyncTask } from "@/services/background-sync-service";
 import { initializeDataVersion } from "@/services/data-version-service";
@@ -16,13 +17,54 @@ import { initializePlayer } from "@/services/playback-controls";
 import { initialize as initializeHeartbeat } from "@/services/position-heartbeat";
 import { initialize as initializePreferredPlaybackRate } from "@/services/preferred-playback-rate-service";
 import { initialize as initializeSleepTimer } from "@/services/sleep-timer-service";
-import { sync } from "@/services/sync-service";
+import {
+  firstSyncError,
+  sync,
+  SyncError,
+  SyncErrorCode,
+} from "@/services/sync-service";
 import { initialize as initializeTrackPlayer } from "@/services/track-player-service";
 import { initializeDevice } from "@/stores/device";
 import { useSession } from "@/stores/session";
 import { logBase } from "@/utils/logger";
 
 const log = logBase.extend("boot-service");
+
+/**
+ * Why the app could not finish booting. Everything the boot sequence does is
+ * either talking to the server or talking to the database, so these are the
+ * only distinctions worth making to the user.
+ */
+export enum BootErrorKind {
+  /** The server could not be reached. */
+  NETWORK = "BootErrorNetwork",
+  /** The server was reached but the request failed. */
+  SERVER = "BootErrorServer",
+  /** Something else went wrong - most likely the local database. */
+  UNEXPECTED = "BootErrorUnexpected",
+}
+
+export interface BootError {
+  kind: BootErrorKind;
+  cause?: unknown;
+}
+
+/**
+ * An unauthorized sync clears the session, which sends the user back to the
+ * sign-in screen on its own - there is nothing to show an error about.
+ */
+function bootErrorFromSync(error: SyncError): BootError | null {
+  switch (error.code) {
+    case SyncErrorCode.UNAUTHORIZED:
+      return null;
+    case SyncErrorCode.NETWORK:
+      return { kind: BootErrorKind.NETWORK };
+    case SyncErrorCode.SERVER:
+      return { kind: BootErrorKind.SERVER };
+    case SyncErrorCode.UNEXPECTED:
+      return { kind: BootErrorKind.UNEXPECTED, cause: error.cause };
+  }
+}
 
 /**
  * Hook that handles application boot sequence.
@@ -39,16 +81,30 @@ const log = logBase.extend("boot-service");
  * 9. Initialize player
  * 10. Register background sync task
  *
+ * A boot that fails part-way leaves the app with nothing usable to show, so
+ * failures are surfaced as `bootError` and the whole sequence can be retried
+ * via `retryBoot` rather than leaving the user on a spinner forever.
+ *
  * @returns isReady - true when boot is complete
  * @returns migrationError - Error if migrations failed
  * @returns initialSyncComplete - true when initial sync has finished
+ * @returns bootError - why boot failed, if it did
+ * @returns retryBoot - runs the boot sequence again
  */
 export function useAppBoot() {
   const [isReady, setIsReady] = useState(false);
   const [initialSyncComplete, setInitialSyncComplete] = useState(false);
+  const [bootError, setBootError] = useState<BootError | null>(null);
+  const [attempt, setAttempt] = useState(0);
   const { success: migrationSuccess, error: migrationError } =
     useDatabaseMigrations();
   const session = useSession((state) => state.session);
+
+  const retryBoot = useCallback(() => {
+    log.info("Retrying boot sequence");
+    setBootError(null);
+    setAttempt((current) => current + 1);
+  }, []);
 
   // Boot (after migrations complete, session-dependent initialization)
   useEffect(() => {
@@ -65,13 +121,25 @@ export function useAppBoot() {
       const { needsInitialSync, needsFullPlaythroughResync } =
         await initializeDataVersion(session);
 
-      if (needsFullPlaythroughResync) {
-        log.info("Starting one-time full event resync");
-        await sync(session, { fullEventResync: true });
-        log.info("One-time full event resync complete");
-      } else if (needsInitialSync) {
-        log.info("Starting initial sync");
-        await sync(session);
+      // The initial sync is the app's only source of library data, so unlike a
+      // periodic sync its failure has to stop the boot and be reported.
+      if (needsFullPlaythroughResync || needsInitialSync) {
+        const fullEventResync = needsFullPlaythroughResync;
+        log.info(
+          fullEventResync
+            ? "Starting one-time full event resync"
+            : "Starting initial sync",
+        );
+
+        const error = firstSyncError(await sync(session, { fullEventResync }));
+
+        if (error) {
+          log.error("Initial sync failed:", error.code);
+          setBootError(bootErrorFromSync(error));
+          setIsReady(true);
+          return;
+        }
+
         log.info("Initial sync complete");
       }
       setInitialSyncComplete(true);
@@ -92,9 +160,14 @@ export function useAppBoot() {
     }
 
     if (migrationSuccess) {
-      boot();
+      boot().catch((error) => {
+        log.error("Boot sequence failed:", error);
+        Sentry.captureException(error);
+        setBootError({ kind: BootErrorKind.UNEXPECTED, cause: error });
+        setIsReady(true);
+      });
     }
-  }, [migrationSuccess, session]);
+  }, [migrationSuccess, session, attempt]);
 
-  return { isReady, migrationError, initialSyncComplete };
+  return { isReady, migrationError, initialSyncComplete, bootError, retryBoot };
 }

--- a/src/services/data-version-service.ts
+++ b/src/services/data-version-service.ts
@@ -27,17 +27,15 @@ export async function getLibraryDataVersion(
  * Initialize the data version store.
  * Loads sync timestamps from DB if not already initialized.
  * Returns whether initial sync is needed (for use by app boot).
+ *
+ * The "needs sync" answers always come from the stored timestamps rather than
+ * the store's `initialized` flag: those timestamps are only written once a sync
+ * has actually applied, so a boot that is retried after a failed initial sync
+ * still knows the sync is outstanding.
  */
 export async function initializeDataVersion(
   session: Session,
 ): Promise<{ needsInitialSync: boolean; needsFullPlaythroughResync: boolean }> {
-  if (useDataVersion.getState().initialized) {
-    log.debug("Already initialized, skipping");
-    return { needsInitialSync: false, needsFullPlaythroughResync: false }; // Already synced if we're initialized
-  }
-
-  log.debug("Initializing");
-
   const [
     { lastSyncTime: lastLibrarySyncTime, libraryDataVersion },
     { lastFullPlaythroughSyncTime },
@@ -46,10 +44,16 @@ export async function initializeDataVersion(
     getServerProfileSyncTimestamps(session),
   ]);
 
-  useDataVersion.setState({
-    initialized: true,
-    libraryDataVersion: libraryDataVersion?.getTime() ?? null,
-  });
+  if (useDataVersion.getState().initialized) {
+    log.debug("Store already initialized, leaving data version as-is");
+  } else {
+    log.debug("Initializing");
+
+    useDataVersion.setState({
+      initialized: true,
+      libraryDataVersion: libraryDataVersion?.getTime() ?? null,
+    });
+  }
 
   return {
     needsInitialSync: lastLibrarySyncTime === null,

--- a/src/services/sync-service.ts
+++ b/src/services/sync-service.ts
@@ -27,7 +27,15 @@ import {
 } from "@/stores/data-version";
 import { getDeviceInfo } from "@/stores/device";
 import { clearSession, useSession } from "@/stores/session";
+import {
+  beginSyncProgress,
+  setSyncSaveProgress,
+  setSyncStage,
+  SyncStage,
+  SyncTask,
+} from "@/stores/sync-progress";
 import { DeviceInfo } from "@/types/device-info";
+import { Result } from "@/types/result";
 import { Session } from "@/types/session";
 import { logBase } from "@/utils/logger";
 
@@ -36,8 +44,37 @@ import { performWalCheckpoint } from "./db-service";
 const log = logBase.extend("sync-service");
 
 // =============================================================================
-// Error Logging
+// Errors
 // =============================================================================
+
+export enum SyncErrorCode {
+  /** The session is no longer valid; it has been cleared. */
+  UNAUTHORIZED = "SyncErrorUnauthorized",
+  /** The server could not be reached. */
+  NETWORK = "SyncErrorNetwork",
+  /** The server was reached but refused or failed the request. */
+  SERVER = "SyncErrorServer",
+  /** Anything else - a thrown exception, usually from the database. */
+  UNEXPECTED = "SyncErrorUnexpected",
+}
+
+export interface SyncError {
+  code: SyncErrorCode;
+  cause?: unknown;
+}
+
+/**
+ * A sync either applied cleanly or it did not. Callers get the failure back
+ * rather than an exception, so they can decide whether to surface it (initial
+ * sync) or quietly try again later (periodic sync).
+ */
+export type SyncOutcome = Result<void, SyncError>;
+
+const SYNC_OK: SyncOutcome = { success: true, result: undefined };
+
+function syncFailure(code: SyncErrorCode, cause?: unknown): SyncOutcome {
+  return { success: false, error: { code, cause } };
+}
 
 function logGQLError(error: ExecuteAuthenticatedError, context: string) {
   switch (error.code) {
@@ -54,6 +91,28 @@ function logGQLError(error: ExecuteAuthenticatedError, context: string) {
   }
 }
 
+/**
+ * Translate a GraphQL failure into a sync failure, clearing the session if the
+ * server no longer accepts our token.
+ */
+function handleGQLError(
+  error: ExecuteAuthenticatedError,
+  context: string,
+): SyncOutcome {
+  logGQLError(error, context);
+
+  switch (error.code) {
+    case ExecuteAuthenticatedErrorCode.UNAUTHORIZED:
+      clearSession();
+      return syncFailure(SyncErrorCode.UNAUTHORIZED);
+    case ExecuteAuthenticatedErrorCode.NETWORK_ERROR:
+      return syncFailure(SyncErrorCode.NETWORK);
+    case ExecuteAuthenticatedErrorCode.SERVER_ERROR:
+    case ExecuteAuthenticatedErrorCode.GQL_ERROR:
+      return syncFailure(SyncErrorCode.SERVER);
+  }
+}
+
 // =============================================================================
 // Library Sync
 // =============================================================================
@@ -65,7 +124,7 @@ interface SyncLibraryOptions {
 export async function syncLibrary(
   session: Session,
   options: SyncLibraryOptions = {},
-): Promise<void> {
+): Promise<SyncOutcome> {
   const { fullResync = false } = options;
 
   if (fullResync) {
@@ -74,45 +133,53 @@ export async function syncLibrary(
     log.debug("Syncing library");
   }
 
-  // 1. Get last sync info from DB; a full resync discards the stored cursor
-  // so the server sends the entire library again
-  const storedSyncInfo = await getLastLibrarySyncInfo(session);
-  const syncInfo = fullResync
-    ? { ...storedSyncInfo, lastSyncTime: null }
-    : storedSyncInfo;
+  try {
+    // 1. Get last sync info from DB; a full resync discards the stored cursor
+    // so the server sends the entire library again
+    const storedSyncInfo = await getLastLibrarySyncInfo(session);
+    const syncInfo = fullResync
+      ? { ...storedSyncInfo, lastSyncTime: null }
+      : storedSyncInfo;
 
-  // 2. Call GraphQL API to get changes
-  const result = await getLibraryChangesSince(session, syncInfo.lastSyncTime);
+    // 2. Call GraphQL API to get changes
+    setSyncStage(SyncTask.LIBRARY, SyncStage.DOWNLOADING);
+    const result = await getLibraryChangesSince(session, syncInfo.lastSyncTime);
 
-  if (!result.success) {
-    logGQLError(result.error, "syncLibrary:");
-
-    if (result.error.code === ExecuteAuthenticatedErrorCode.UNAUTHORIZED) {
-      clearSession();
+    if (!result.success) {
+      setSyncStage(SyncTask.LIBRARY, SyncStage.FAILED);
+      return handleGQLError(result.error, "syncLibrary:");
     }
-    return;
+
+    const changes = result.result;
+
+    if (!changes) {
+      log.info("No library changes to apply");
+      setSyncStage(SyncTask.LIBRARY, SyncStage.DONE);
+      return SYNC_OK;
+    }
+
+    // 3. Apply changes to DB
+    const { newDataAsOf } = await applyLibraryChanges(
+      session,
+      changes as LibraryChangesInput,
+      syncInfo,
+      ({ detail, current, total }) =>
+        setSyncSaveProgress(SyncTask.LIBRARY, detail, current, total),
+    );
+
+    // 4. Update global data version store
+    if (newDataAsOf) {
+      setLibraryDataVersion(newDataAsOf);
+    }
+
+    log.debug("Library sync complete");
+    setSyncStage(SyncTask.LIBRARY, SyncStage.DONE);
+    return SYNC_OK;
+  } catch (error) {
+    log.error("syncLibrary: unexpected failure", error);
+    setSyncStage(SyncTask.LIBRARY, SyncStage.FAILED);
+    return syncFailure(SyncErrorCode.UNEXPECTED, error);
   }
-
-  const changes = result.result;
-
-  if (!changes) {
-    log.info("No library changes to apply");
-    return;
-  }
-
-  // 3. Apply changes to DB
-  const { newDataAsOf } = await applyLibraryChanges(
-    session,
-    changes as LibraryChangesInput,
-    syncInfo,
-  );
-
-  // 4. Update global data version store
-  if (newDataAsOf) {
-    setLibraryDataVersion(newDataAsOf);
-  }
-
-  log.debug("Library sync complete");
 }
 
 // =============================================================================
@@ -145,7 +212,7 @@ const eventTypeMap: Record<string, PlaybackEventType> = {
 export async function syncPlaybackEvents(
   session: Session,
   options: SyncPlaybackEventsOptions = {},
-): Promise<void> {
+): Promise<SyncOutcome> {
   const { fullResync = false, deviceInfoOverride } = options;
 
   if (fullResync) {
@@ -154,72 +221,80 @@ export async function syncPlaybackEvents(
     log.debug("Syncing events (V2)");
   }
 
-  // 1. Get unsynced events from DB
-  const deviceInfo = deviceInfoOverride ?? (await getDeviceInfo());
-  const syncData = await getEventSyncData(session);
+  try {
+    // 1. Get unsynced events from DB
+    const deviceInfo = deviceInfoOverride ?? (await getDeviceInfo());
+    const syncData = await getEventSyncData(session);
 
-  // 2. Build GraphQL input (events only - no playthroughs)
-  const input: SyncEventsInput = {
-    lastSyncTime: fullResync ? null : syncData.lastSyncTime,
-    device: {
-      id: deviceInfo.id,
-      type: deviceTypeMap[deviceInfo.type] ?? DeviceTypeInput.Android,
-      brand: deviceInfo.brand,
-      modelName: deviceInfo.modelName,
-      osName: deviceInfo.osName,
-      osVersion: deviceInfo.osVersion,
-      appId: deviceInfo.appId,
-      appVersion: deviceInfo.appVersion,
-      appBuild: deviceInfo.appBuild,
-    },
-    events: syncData.unsyncedEvents.map((e) => ({
-      id: e.id,
-      playthroughId: e.playthroughId,
-      mediaId: e.mediaId,
-      type: eventTypeMap[e.type] ?? PlaybackEventType.Play,
-      timestamp: e.timestamp,
-      position: e.position,
-      playbackRate: e.playbackRate,
-      fromPosition: e.fromPosition,
-      toPosition: e.toPosition,
-      previousRate: e.previousRate,
-    })),
-  };
+    // 2. Build GraphQL input (events only - no playthroughs)
+    const input: SyncEventsInput = {
+      lastSyncTime: fullResync ? null : syncData.lastSyncTime,
+      device: {
+        id: deviceInfo.id,
+        type: deviceTypeMap[deviceInfo.type] ?? DeviceTypeInput.Android,
+        brand: deviceInfo.brand,
+        modelName: deviceInfo.modelName,
+        osName: deviceInfo.osName,
+        osVersion: deviceInfo.osVersion,
+        appId: deviceInfo.appId,
+        appVersion: deviceInfo.appVersion,
+        appBuild: deviceInfo.appBuild,
+      },
+      events: syncData.unsyncedEvents.map((e) => ({
+        id: e.id,
+        playthroughId: e.playthroughId,
+        mediaId: e.mediaId,
+        type: eventTypeMap[e.type] ?? PlaybackEventType.Play,
+        timestamp: e.timestamp,
+        position: e.position,
+        playbackRate: e.playbackRate,
+        fromPosition: e.fromPosition,
+        toPosition: e.toPosition,
+        previousRate: e.previousRate,
+      })),
+    };
 
-  // 3. Call GraphQL API
-  const result = await syncEvents(session, input);
+    // 3. Call GraphQL API
+    setSyncStage(SyncTask.EVENTS, SyncStage.DOWNLOADING);
+    const result = await syncEvents(session, input);
 
-  if (!result.success) {
-    logGQLError(result.error, "syncPlaythroughs:");
-    if (result.error.code === ExecuteAuthenticatedErrorCode.UNAUTHORIZED) {
-      clearSession();
+    if (!result.success) {
+      setSyncStage(SyncTask.EVENTS, SyncStage.FAILED);
+      return handleGQLError(result.error, "syncPlaythroughs:");
     }
-    return;
+
+    const syncResult = result.result.syncEvents;
+    if (!syncResult) {
+      log.info("No event sync result returned");
+      setSyncStage(SyncTask.EVENTS, SyncStage.DONE);
+      return SYNC_OK;
+    }
+
+    // 4. Apply result to DB (events only, rebuild affected playthroughs)
+    await applyEventSyncResult(
+      session,
+      syncResult,
+      syncData.unsyncedEvents.map((e) => e.id),
+      ({ detail, current, total }) =>
+        setSyncSaveProgress(SyncTask.EVENTS, detail, current, total),
+    );
+
+    // 5. If this was a full resync, update the timestamp
+    if (fullResync) {
+      await setLastFullPlaythroughSyncTime(session, new Date());
+    }
+
+    // 6. Notify UI that playthrough data changed
+    bumpPlaythroughDataVersion();
+
+    log.debug("Event sync complete");
+    setSyncStage(SyncTask.EVENTS, SyncStage.DONE);
+    return SYNC_OK;
+  } catch (error) {
+    log.error("syncPlaybackEvents: unexpected failure", error);
+    setSyncStage(SyncTask.EVENTS, SyncStage.FAILED);
+    return syncFailure(SyncErrorCode.UNEXPECTED, error);
   }
-
-  const syncResult = result.result.syncEvents;
-  if (!syncResult) {
-    log.info("No event sync result returned");
-    return;
-  }
-
-  // 4. Apply result to DB (events only, rebuild affected playthroughs)
-  await applyEventSyncResult(
-    session,
-    syncResult,
-    syncData.unsyncedEvents.map((e) => e.id),
-  );
-
-  // 5. If this was a full resync, update the timestamp
-  if (fullResync) {
-    await setLastFullPlaythroughSyncTime(session, new Date());
-  }
-
-  // 6. Notify UI that playthrough data changed
-  bumpPlaythroughDataVersion();
-
-  log.debug("Event sync complete");
-  return;
 }
 
 // =============================================================================
@@ -231,12 +306,36 @@ interface SyncOptions {
   fullLibraryResync?: boolean;
 }
 
-export async function sync(session: Session, options: SyncOptions = {}) {
+/**
+ * The library and event syncs are independent, so each reports its own outcome
+ * and one failing does not hide the other's result.
+ */
+export interface SyncResults {
+  library: SyncOutcome;
+  events: SyncOutcome;
+}
+
+/** The first failure across both halves of a sync, if either failed. */
+export function firstSyncError(results: SyncResults): SyncError | null {
+  if (!results.library.success) return results.library.error;
+  if (!results.events.success) return results.events.error;
+  return null;
+}
+
+export async function sync(
+  session: Session,
+  options: SyncOptions = {},
+): Promise<SyncResults> {
   const { fullEventResync = false, fullLibraryResync = false } = options;
-  return Promise.all([
+
+  beginSyncProgress();
+
+  const [library, events] = await Promise.all([
     syncLibrary(session, { fullResync: fullLibraryResync }),
     syncPlaybackEvents(session, { fullResync: fullEventResync }),
   ]);
+
+  return { library, events };
 }
 
 // =============================================================================
@@ -259,15 +358,15 @@ export function useForegroundSync(appState: AppStateStatus) {
         return;
       }
 
-      try {
-        await sync(session);
+      const error = firstSyncError(await sync(session));
 
-        log.debug("ForegroundSync: performing WAL checkpoint");
-        performWalCheckpoint();
+      log.debug("ForegroundSync: performing WAL checkpoint");
+      performWalCheckpoint();
 
+      if (error) {
+        log.error("ForegroundSync: failed:", error.code);
+      } else {
         log.info("ForegroundSync: completed successfully");
-      } catch (error) {
-        log.error("ForegroundSync: failed:", error);
       }
     };
 
@@ -294,13 +393,9 @@ export function usePullToRefresh(session: Session) {
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
-    try {
-      await sync(session);
-    } catch (error) {
-      log.error("Pull-to-refresh sync error:", error);
-    } finally {
-      setRefreshing(false);
-    }
+    const error = firstSyncError(await sync(session));
+    if (error) log.error("Pull-to-refresh sync error:", error.code);
+    setRefreshing(false);
   }, [session]);
 
   return { refreshing, onRefresh };

--- a/src/stores/sync-progress.ts
+++ b/src/stores/sync-progress.ts
@@ -1,0 +1,94 @@
+import { create } from "zustand";
+
+/**
+ * The two halves of a sync. They run concurrently, so each reports its own
+ * progress rather than sharing one linear set of steps.
+ */
+export enum SyncTask {
+  LIBRARY = "library",
+  EVENTS = "events",
+}
+
+export enum SyncStage {
+  /** Not started, or finished long enough ago that we no longer show it. */
+  PENDING = "pending",
+  /**
+   * Waiting on the server. The response arrives in one piece, so there is no
+   * meaningful progress to report during this stage.
+   */
+  DOWNLOADING = "downloading",
+  /** Writing to the local database; `current` and `total` count rows. */
+  SAVING = "saving",
+  DONE = "done",
+  FAILED = "failed",
+}
+
+export interface TaskProgress {
+  stage: SyncStage;
+  /** What is being written right now, e.g. "books". Only set while SAVING. */
+  detail: string | null;
+  current: number;
+  total: number;
+}
+
+interface SyncProgressState {
+  tasks: Record<SyncTask, TaskProgress>;
+}
+
+const pendingTask = (): TaskProgress => ({
+  stage: SyncStage.PENDING,
+  detail: null,
+  current: 0,
+  total: 0,
+});
+
+export const initialSyncProgressState: SyncProgressState = {
+  tasks: {
+    [SyncTask.LIBRARY]: pendingTask(),
+    [SyncTask.EVENTS]: pendingTask(),
+  },
+};
+
+export const useSyncProgress = create<SyncProgressState>(
+  () => initialSyncProgressState,
+);
+
+function updateTask(task: SyncTask, changes: Partial<TaskProgress>) {
+  useSyncProgress.setState((state) => ({
+    tasks: { ...state.tasks, [task]: { ...state.tasks[task], ...changes } },
+  }));
+}
+
+/** Reset both tasks back to pending at the start of a sync. */
+export function beginSyncProgress() {
+  useSyncProgress.setState(initialSyncProgressState);
+}
+
+/**
+ * Move a task to a new stage. Row counts only mean something while saving, so
+ * they are cleared on every other transition.
+ */
+export function setSyncStage(task: SyncTask, stage: SyncStage) {
+  if (stage === SyncStage.SAVING) {
+    updateTask(task, { stage });
+  } else {
+    updateTask(task, { stage, detail: null, current: 0, total: 0 });
+  }
+}
+
+/** Report how far through writing a task's rows we are. */
+export function setSyncSaveProgress(
+  task: SyncTask,
+  detail: string,
+  current: number,
+  total: number,
+) {
+  updateTask(task, { stage: SyncStage.SAVING, detail, current, total });
+}
+
+/**
+ * Reset store to initial state for testing.
+ */
+export function resetForTesting() {
+  useSyncProgress.setState(initialSyncProgressState, true);
+}

--- a/test/jest-setup.ts
+++ b/test/jest-setup.ts
@@ -393,6 +393,23 @@ jest.mock("expo-background-task", () => ({
   },
 }));
 
+// =============================================================================
+// Sentry (Native Module)
+// =============================================================================
+// @sentry/core ships untranspiled ESM, so importing the real SDK fails under
+// jest. Crash reporting has no observable behaviour to test anyway.
+
+export const mockSentryCaptureException = jest.fn();
+
+jest.mock("@sentry/react-native", () => ({
+  captureException: (error: unknown) => mockSentryCaptureException(error),
+  init: jest.fn(),
+  wrap: (component: unknown) => component,
+  reactNavigationIntegration: () => ({
+    registerNavigationContainer: jest.fn(),
+  }),
+}));
+
 /**
  * Get the task callback defined via TaskManager.defineTask.
  * Use this to manually invoke the background task in tests.


### PR DESCRIPTION
A fresh login against a library with more than ~1638 media items dies with `Call to function 'NativeDatabase.prepareSync' has been rejected. → Caused by: Error code : too many SQL variables`, leaving the app on a spinner forever with no on-screen indication anything went wrong.

Three separate problems, in the order they bite.

## 1. The crash: batched upserts blow SQLite's parameter limit

`applyLibraryChanges` upserted each entity type in a single multi-row `INSERT`. SQLite binds one parameter per column per row and rejects any statement over `SQLITE_MAX_VARIABLE_NUMBER` — 32766, since neither expo-sqlite nor better-sqlite3 overrides the SQLite 3.32+ default. `media` is the widest table at 20 columns, so **1638 rows was the hard ceiling**. Incremental syncs stay small, which is why only the first sync hit it.

New `src/db/chunk.ts` derives batch sizes from each table's column count (via `getTableColumns`) against a 30,000-parameter budget. Applied to all nine library upserts, the deletion `inArray`, and `markEventsSynced`.

The same bug sat in `upsertPlaybackEvents`, which chunked by *row count* — `EVENT_INSERT_CHUNK_SIZE = 10_000` against a 12-column table is 120,000 parameters, failing above 2730 events.

## 2. The silence: failures had nowhere to go

`syncLibrary`/`syncPlaybackEvents` swallowed GraphQL errors with a bare `return`, and a thrown DB error rejected `boot()`'s promise with nothing to catch it. Because `isReady` was already `true` from the pre-login boot and `initialSyncComplete` never flipped, the layout sat on its spinner branch indefinitely.

- Both sync functions now return `Result<void, SyncError>` (`UNAUTHORIZED`/`NETWORK`/`SERVER`/`UNEXPECTED`) and never throw. `sync()` returns both outcomes separately so one failure can't mask the other.
- `useAppBoot` exposes `bootError` and `retryBoot`; a new `ErrorScreen` renders it with "Try again" and a "Sign out" escape hatch. It also replaces the unstyled bare-text screen the migration error used to get.
- The background task now checks the returned outcome — it only caught throws before, so a failed background sync would have reported `Success` and the OS would never back off.
- `initializeDataVersion` early-returned `needsInitialSync: false` once the store was initialized, so a retry after a failed first sync would skip the sync and declare success with an empty library. It now derives that from the stored timestamps, which are only written once a sync has actually applied.

An `UNAUTHORIZED` failure deliberately shows no error screen — the session is already cleared, so the user lands back on sign-in.

## 3. The wait: no sense of progress

The boot screen now names the step in progress and counts rows, instead of spinning silently:

```
Library                          Saving books…
████████████░░░░░░░░░░░░░░░░
1,240 of 5,000

Listening progress                       Done
████████████████████████████
```

The two halves of a sync run concurrently, so each reports its own stage rather than sharing one linear step list. Progress is driven by callbacks from the chunk loops above, so the DB layer stays store-agnostic. `rebuildPlaythroughs` reports per playthrough too — it's a serial loop that would otherwise be a silent tail after the bar hit 100%.

The download stage stays indeterminate (the GraphQL response arrives in one piece) but is at least labelled. If that turns out to be the long pole for big libraries, the fix is server-side pagination of `libraryChangesSince`.

## Two test bugs this surfaced

Both were passing while asserting nothing real:

- `background-sync-service.test.ts` dispatched its fetch mock on `body.operationName`, which `executeAuthenticated` never sends — so every request fell through to the mock's 400 branch, and "runs full sync cycle and returns success" was running two *failed* syncs. Its sibling passed only because `mockRejectedValueOnce` left the second concurrent fetch unmocked, so `response.ok` threw on `undefined`.
- `emptySyncEventsResult()` already includes the `syncEvents` wrapper, and four call sites wrapped it again (one under the stale key `syncProgress`). Those event syncs hit the `!syncResult` early return and no-oped.

## Testing

705 tests pass (70 suites), `npx tsc` and `npm run lint` clean.

New regression coverage: 2 tests inserting 2000 media / 5000 people that reproduce `too many SQL variables` against the old code; 4 boot-service tests including one asserting a retry *actually re-runs* the outstanding sync (it fails against the old `initializeDataVersion`); 3 sync-service tests recording every progress emission during the write; 9 component tests for the two new screens.

`test/jest-setup.ts` gains a Sentry mock — `@sentry/core` ships untranspiled ESM and can't be imported under jest.

https://claude.ai/code/session_015DcGbVuqFpDprgWh7ZAVkE