### PR TITLE
Fix the library grid jumping while scrolling

### DIFF
--- a/src/components/screens/library-screen/FullLibrary.tsx
+++ b/src/components/screens/library-screen/FullLibrary.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { Platform, RefreshControl, StyleSheet, Text, View } from "react-native";
 import { useKeyboardState } from "react-native-keyboard-controller";
 import Animated from "react-native-reanimated";
@@ -14,17 +13,10 @@ import {
   usePaginatedLibraryData,
 } from "@/services/library-service";
 import { usePullToRefresh } from "@/services/sync-service";
-import { useScreen } from "@/stores/screen";
 import { useTrackPlayer } from "@/stores/track-player";
 import { Colors } from "@/styles/colors";
 import { Session } from "@/types/session";
 
-// FlatList layout constants for 2-column grid
-const FLATLIST_PADDING = 8;
-const TILE_PADDING = 8;
-const TILE_MARGIN_BOTTOM = 8;
-const TILE_GAP = 12; // gap between image and text in Tile component
-const TEXT_HEIGHT = 46; // approximate height for 3 lines of text (title, author, narrator)
 const NUM_COLUMNS = 2;
 
 type FullLibraryProps = {
@@ -40,7 +32,6 @@ export function FullLibrary({
   scrollHandler,
   topInset = 0,
 }: FullLibraryProps) {
-  const screenWidth = useScreen((state) => state.screenWidth);
   const { bottom: safeAreaBottom } = useSafeAreaInsets();
   const playerLoaded = useTrackPlayer((state) => !!state.playthrough);
 
@@ -60,27 +51,6 @@ export function FullLibrary({
   const page = usePaginatedLibraryData(PAGE_SIZE, getPage, getCursor);
   const { items: media, hasMore, loadMore } = page;
   const { refreshing, onRefresh } = usePullToRefresh(session);
-
-  // Calculate item height for getItemLayout optimization
-  // Tile width = (screenWidth - flatlist padding) / numColumns
-  // Image width = tile width - tile padding * 2
-  // Image height = image width (square aspect ratio)
-  // Total item height = image height + gap + text height + margin bottom
-  const itemHeight = useMemo(() => {
-    const contentWidth = screenWidth - FLATLIST_PADDING * 2;
-    const tileWidth = contentWidth / NUM_COLUMNS;
-    const imageWidth = tileWidth - TILE_PADDING * 2;
-    return imageWidth + TILE_GAP + TEXT_HEIGHT + TILE_MARGIN_BOTTOM;
-  }, [screenWidth]);
-
-  const getItemLayout = useMemo(
-    () => (_data: unknown, index: number) => ({
-      length: itemHeight,
-      offset: itemHeight * index,
-      index,
-    }),
-    [itemHeight],
-  );
 
   if (!media) {
     return null;
@@ -140,7 +110,10 @@ export function FullLibrary({
           <MediaTile media={item} />
         </View>
       )}
-      getItemLayout={getItemLayout}
+      // No getItemLayout: tile rows are not a fixed height (the text block
+      // varies with how many lines it renders), and when getItemLayout is set
+      // VirtualizedList stops measuring cells entirely, so every estimate error
+      // accumulates into the spacer above the viewport and the content jumps.
       removeClippedSubviews={Platform.OS === "android"}
       maxToRenderPerBatch={10}
       windowSize={5}

--- a/src/components/screens/search-screen/SearchResults.tsx
+++ b/src/components/screens/search-screen/SearchResults.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import { Platform, StyleSheet, Text, View } from "react-native";
 import { useKeyboardState } from "react-native-keyboard-controller";
 import Animated, {
@@ -12,17 +12,10 @@ import FontAwesome6 from "@expo/vector-icons/FontAwesome6";
 import { MediaTile } from "@/components/Tiles";
 import { PAGE_SIZE, PLAYER_HEIGHT, TAB_BAR_BASE_HEIGHT } from "@/constants";
 import { getSearchedMedia, useLibraryData } from "@/services/library-service";
-import { useScreen } from "@/stores/screen";
 import { useTrackPlayer } from "@/stores/track-player";
 import { Colors } from "@/styles/colors";
 import { Session } from "@/types/session";
 
-// FlatList layout constants for 2-column grid
-const FLATLIST_PADDING = 8;
-const TILE_PADDING = 8;
-const TILE_MARGIN_BOTTOM = 8;
-const TILE_GAP = 12;
-const TEXT_HEIGHT = 46;
 const NUM_COLUMNS = 2;
 
 type SearchResultsProps = {
@@ -34,7 +27,6 @@ const MINI_PROGRESS_BAR_HEIGHT = 2;
 
 export function SearchResults(props: SearchResultsProps) {
   const { session, searchQuery } = props;
-  const screenWidth = useScreen((state) => state.screenWidth);
   const { bottom: safeAreaBottom } = useSafeAreaInsets();
   const playerLoaded = useTrackPlayer((state) => !!state.playthrough);
 
@@ -61,22 +53,6 @@ export function SearchResults(props: SearchResultsProps) {
   const media = useLibraryData(
     () => getSearchedMedia(session, PAGE_SIZE, searchQuery),
     [searchQuery],
-  );
-
-  const itemHeight = useMemo(() => {
-    const contentWidth = screenWidth - FLATLIST_PADDING * 2;
-    const tileWidth = contentWidth / NUM_COLUMNS;
-    const imageWidth = tileWidth - TILE_PADDING * 2;
-    return imageWidth + TILE_GAP + TEXT_HEIGHT + TILE_MARGIN_BOTTOM;
-  }, [screenWidth]);
-
-  const getItemLayout = useMemo(
-    () => (_data: unknown, index: number) => ({
-      length: itemHeight,
-      offset: itemHeight * index,
-      index,
-    }),
-    [itemHeight],
   );
 
   if (!media) {
@@ -118,7 +94,8 @@ export function SearchResults(props: SearchResultsProps) {
           <MediaTile media={item} />
         </View>
       )}
-      getItemLayout={getItemLayout}
+      // No getItemLayout: see FullLibrary — tile rows are not a fixed height,
+      // and a wrong estimate makes the content jump while scrolling.
       removeClippedSubviews={Platform.OS === "android"}
       maxToRenderPerBatch={10}
       windowSize={5}


### PR DESCRIPTION
Scrolling the library on Android would shift the content by a small amount every so often — roughly the height of the header — most notably after a new page of items loaded in.

Both the library grid and the search results passed `getItemLayout` with a row height computed from a fixed `TEXT_HEIGHT` of 46px, meant to stand in for the three lines of title/author/narrator under each cover. That estimate is wrong in both of its terms:

* The text block is not 46px and is not even a constant. Three single-line labels at 16/14/12px measure noticeably taller than that on Android, and a tile whose media has no narrators renders one line less.
* The offsets ignore the `contentContainerStyle` `paddingTop` the redesign added to the library grid (status bar + collapsible header, ~72px), so every offset it reports is short by a header's worth on top of the per-row error.

Neither is self-correcting, because VirtualizedList only attaches `onLayout` to its cells when `getItemLayout` is absent (`shouldListenForLayout` in `VirtualizedList.js`). With it present, nothing is ever measured and every offset comes from the estimate. The spacer standing in for the rows above the viewport is sized as `offset(first) - offset(0)`, so each time the render window's `first` index advances, the rows that scrolled out are replaced by a spacer built from the declared height rather than the height they actually occupied, and everything below shifts by the difference. A single row's worth is a few pixels; a window recompute that moves several rows at once — as happens when a page appends — is the visible jump. The error also compounds with index, which is why it got worse the deeper the list went.

So the estimate goes. Rows now measure themselves, and with `getItemLayout` gone VirtualizedList additionally constrains its tail spacer to the highest measured cell, which is the mitigation it has for exactly this. The only thing given up is accurate `scrollToIndex`, which neither screen uses.

Verified on an Android device against a library large enough to page several times.