### PR TITLE
Read by, not Read By

### DIFF
--- a/src/components/screens/person-screen/MediaByNarrators.tsx
+++ b/src/components/screens/person-screen/MediaByNarrators.tsx
@@ -72,8 +72,8 @@ function MediaByNarrator(props: MediaByNarratorProps) {
         <HeaderButton
           label={
             narrator.name === personName
-              ? `Read By ${narrator.name}`
-              : `Read As ${narrator.name}`
+              ? `Read by ${narrator.name}`
+              : `Read as ${narrator.name}`
           }
           onPress={navigateToNarrator}
           showCaret={hasMore}


### PR DESCRIPTION
One-string fix: `MediaByNarrators` was the only surface capitalizing the verb ("Read By ..." / "Read As ..."); everywhere else says "Read by". Matches the server-side credit sweep (ambry#1233–#1235) landing today.

https://claude.ai/code/session_01GttiY8Xqm2cyn4qn9AZCpx