### PR TITLE
Collapse tiles into editions, like the web app does

### DIFF
--- a/src/components/MultiThumbnailImage.tsx
+++ b/src/components/MultiThumbnailImage.tsx
@@ -3,14 +3,23 @@ import { ImageStyle } from "expo-image";
 
 import { DownloadedThumbnails, Thumbnails } from "@/services/library-service";
 import { Colors, decorative } from "@/styles/colors";
+import { STACK_LIMIT } from "@/utils/editions";
 
 import { ThumbnailImage } from "./ThumbnailImage";
 
+type ThumbnailPair = {
+  thumbnails: Thumbnails | null;
+  downloadedThumbnails: DownloadedThumbnails | null;
+};
+
 type MultiThumbnailImageProps = {
-  thumbnailPairs: {
-    thumbnails: Thumbnails | null;
-    downloadedThumbnails: DownloadedThumbnails | null;
-  }[];
+  /**
+   * Covers front-to-back: index 0 faces the reader. Callers order these by
+   * whatever they are stacking — newest edition first for a book, first part
+   * first for a set — but the front of the stack is always the thing the tile
+   * stands for. See `@/utils/editions`.
+   */
+  thumbnailPairs: ThumbnailPair[];
   size: "extraSmall" | "small" | "medium" | "large" | "extraLarge";
   style?: StyleProp<ViewStyle>;
   imageStyle?: StyleProp<ImageStyle>;
@@ -18,71 +27,43 @@ type MultiThumbnailImageProps = {
 
 export function MultiThumbnailImage(props: MultiThumbnailImageProps) {
   const { thumbnailPairs, size, style, imageStyle } = props;
+  const covers = thumbnailPairs.slice(0, STACK_LIMIT);
 
-  if (thumbnailPairs.length === 0)
-    return <View style={[styles.container, style]} />;
+  if (covers.length === 0) return <View style={[styles.container, style]} />;
 
-  if (thumbnailPairs.length === 1)
+  if (covers.length === 1)
     return (
       <ThumbnailImage
-        {...thumbnailPairs[0]}
+        {...covers[0]!}
         size={size}
         style={style}
         imageStyle={imageStyle}
       />
     );
 
-  if (thumbnailPairs.length === 2)
-    return (
-      <View style={styles.multiContainer}>
-        <View style={styles.firstOfTwo}>
-          <ThumbnailImage
-            {...thumbnailPairs[0]}
-            size={size}
-            style={[styles.blackBorder, style]}
-            imageStyle={imageStyle}
-          />
-        </View>
-        <View style={styles.secondOfTwo}>
-          <ThumbnailImage
-            {...thumbnailPairs[1]}
-            size={size}
-            style={[styles.blackBorder, style]}
-            imageStyle={imageStyle}
-          />
-        </View>
-      </View>
-    );
+  const offsets = covers.length === 2 ? twoUp : threeUp;
 
-  if (thumbnailPairs.length >= 3)
-    return (
-      <View style={styles.multiContainer}>
-        <View style={styles.firstOfThree}>
+  // Painted back to front, so the first cover ends up on top. The backmost
+  // layer stays in normal flow and gives the stack its height; the rest sit
+  // on top of it.
+  const layers = covers
+    .map((pair, index) => ({ pair, offset: offsets[index]! }))
+    .reverse();
+
+  return (
+    <View style={styles.multiContainer}>
+      {layers.map(({ pair, offset }, index) => (
+        <View key={index} style={[offset, index === 0 ? null : styles.overlay]}>
           <ThumbnailImage
-            {...thumbnailPairs[0]}
+            {...pair}
             size={size}
             style={[styles.blackBorder, style]}
             imageStyle={imageStyle}
           />
         </View>
-        <View style={styles.secondOfThree}>
-          <ThumbnailImage
-            {...thumbnailPairs[1]}
-            size={size}
-            style={[styles.blackBorder, style]}
-            imageStyle={imageStyle}
-          />
-        </View>
-        <View style={styles.thirdOfThree}>
-          <ThumbnailImage
-            {...thumbnailPairs[2]}
-            size={size}
-            style={[styles.blackBorder, style]}
-            imageStyle={imageStyle}
-          />
-        </View>
-      </View>
-    );
+      ))}
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
@@ -97,28 +78,28 @@ const styles = StyleSheet.create({
   multiContainer: {
     position: "relative",
   },
-  firstOfTwo: {
-    transform: [{ translateX: 4 }, { translateY: 4 }, { scale: 0.95 }],
-  },
-  secondOfTwo: {
+  overlay: {
     position: "absolute",
     top: 0,
     width: "100%",
+  },
+  frontOfTwo: {
     transform: [{ translateX: -4 }, { translateY: -4 }, { scale: 0.95 }],
   },
-  firstOfThree: {
-    transform: [{ translateX: 8 }, { translateY: 8 }, { scale: 0.9 }],
+  backOfTwo: {
+    transform: [{ translateX: 4 }, { translateY: 4 }, { scale: 0.95 }],
   },
-  secondOfThree: {
-    position: "absolute",
-    top: 0,
-    width: "100%",
-    transform: [{ scale: 0.9 }],
-  },
-  thirdOfThree: {
-    position: "absolute",
-    top: 0,
-    width: "100%",
+  frontOfThree: {
     transform: [{ translateX: -8 }, { translateY: -8 }, { scale: 0.9 }],
   },
+  middleOfThree: {
+    transform: [{ scale: 0.9 }],
+  },
+  backOfThree: {
+    transform: [{ translateX: 8 }, { translateY: 8 }, { scale: 0.9 }],
+  },
 });
+
+// front-to-back, matching the order callers hand us
+const twoUp = [styles.frontOfTwo, styles.backOfTwo];
+const threeUp = [styles.frontOfThree, styles.middleOfThree, styles.backOfThree];

--- a/src/components/Tiles.tsx
+++ b/src/components/Tiles.tsx
@@ -17,8 +17,17 @@ import {
   Thumbnails,
 } from "@/services/library-service";
 import { Colors, interactive, surface } from "@/styles/colors";
-import { useNavigateToBookCallback } from "@/utils/hooks";
-import { recordingTitle } from "@/utils/titles";
+import {
+  Edition,
+  EditionMedia,
+  stackedRepresentatives,
+  toEditions,
+} from "@/utils/editions";
+import {
+  useNavigateToBookCallback,
+  useNavigateToMediaCallback,
+} from "@/utils/hooks";
+import { partsLabel, recordingTitle } from "@/utils/titles";
 
 import { BookDetailsText } from "./BookDetailsText";
 import { MultiThumbnailImage } from "./MultiThumbnailImage";
@@ -64,6 +73,20 @@ type Media = {
   isOnSavedShelf?: boolean;
 };
 
+/** A recording a book tile can collapse into editions. */
+type StackableMedia = Media & EditionMedia;
+
+/** What a set needs to describe itself on its own tile. */
+type SetInfo = {
+  id: string;
+  partsTotal: number | null;
+  partWord: string | null;
+  partWordPlural: string | null;
+};
+
+/** A recording that knows which set it belongs to, if any. */
+export type EditionTileMedia = StackableMedia & { set: SetInfo | null };
+
 type Book = {
   id: string;
   title: string;
@@ -78,7 +101,7 @@ type SeriesBook = {
 };
 
 type MediaProp = Media & { book: Book };
-type BookProp = Book & { media: Media[] };
+type BookProp = Book & { media: StackableMedia[] };
 type SeriesBookProp = SeriesBook & { book: BookProp };
 
 type MediaTileProps = {
@@ -115,6 +138,12 @@ type TileTextProps = {
   media: Media[];
 };
 
+type EditionTileProps = {
+  edition: Edition<EditionTileMedia>;
+  book: Book;
+  style?: StyleProp<ViewStyle>;
+};
+
 type PersonTileProps = {
   personId: string;
   name: string;
@@ -142,13 +171,25 @@ export const MediaTile = React.memo(function MediaTile(props: MediaTileProps) {
   );
 });
 
+/**
+ * A book, collapsed to one cover per edition.
+ *
+ * The recursive collapse means a book tile shows editions, not recordings: a
+ * book whose only edition is a three-part set is one cover, not three, and the
+ * set only fans out where it is the tile. Handing `Tile` the representatives
+ * also gives it the right click target for free — a lone edition leaves one
+ * entry, so the tile goes straight to it and skips the book screen.
+ */
 export const BookTile = React.memo(function BookTile(props: BookTileProps) {
   const { book, style } = props;
-  if (book.media.length === 0) return null;
+  const covers = useEditionCovers(book.media);
+
+  if (covers.length === 0) return null;
+
   return (
     <Tile
       book={book}
-      media={book.media}
+      media={covers}
       style={style}
       playthroughStatus={getBestPlaythroughStatus(book.media)}
       isOnSavedShelf={isAnyMediaOnSavedShelf(book.media)}
@@ -160,11 +201,14 @@ export const SeriesBookTile = React.memo(function SeriesBookTile(
   props: SeriesBookTileProps,
 ) {
   const { seriesBook, style } = props;
-  if (seriesBook.book.media.length === 0) return null;
+  const covers = useEditionCovers(seriesBook.book.media);
+
+  if (covers.length === 0) return null;
+
   return (
     <Tile
       book={seriesBook.book}
-      media={seriesBook.book.media}
+      media={covers}
       seriesBook={seriesBook}
       style={style}
       playthroughStatus={getBestPlaythroughStatus(seriesBook.book.media)}
@@ -173,6 +217,74 @@ export const SeriesBookTile = React.memo(function SeriesBookTile(
   );
 });
 
+/**
+ * One edition, rendered as itself.
+ *
+ * This is the one place a set fans out: its parts stack in part order, part 1
+ * facing front, under the book's title and a count of its parts. Everywhere
+ * else a set is one cover inside a larger stack. Either kind opens the
+ * recording it stands for — for a set that is its first part, whose screen
+ * carries the rest of the set.
+ */
+export const EditionTile = React.memo(function EditionTile(
+  props: EditionTileProps,
+) {
+  const { edition, book, style } = props;
+  const set = edition.kind === "set" ? edition.representative.set : null;
+
+  const navigateToEdition = useNavigateToMediaCallback(
+    edition.representative,
+    book,
+  );
+
+  return (
+    <Pressable onPress={navigateToEdition}>
+      <View style={[styles.container, style]}>
+        <TileImage
+          media={edition.media}
+          playthroughStatus={getBestPlaythroughStatus(edition.media)}
+          isOnSavedShelf={isAnyMediaOnSavedShelf(edition.media)}
+        />
+        <View>
+          <BookDetailsText
+            baseFontSize={16}
+            title={
+              set
+                ? book.title
+                : recordingTitle(edition.representative.title, book.title)
+            }
+            narrators={
+              set
+                ? undefined
+                : edition.representative.narrators.map((n) => n.name)
+            }
+          />
+          {set && (
+            <Text style={styles.partsLabel} numberOfLines={1}>
+              {partsLabel(set, edition.media.length)}
+            </Text>
+          )}
+        </View>
+      </View>
+    </Pressable>
+  );
+});
+
+function useEditionCovers(media: StackableMedia[]) {
+  return React.useMemo(
+    () => stackedRepresentatives(toEditions(media)),
+    [media],
+  );
+}
+
+/**
+ * The tile every stack is built from.
+ *
+ * `media` arrives already collapsed and in front-to-back order: index 0 is the
+ * cover that faces the reader and the thing the tile stands for. One entry
+ * means the tile navigates straight to that recording; several mean it stands
+ * for the book as a whole and opens the book screen.
+ */
 export const Tile = React.memo(function Tile(props: TileProps) {
   const { book, media, seriesBook, style, playthroughStatus, isOnSavedShelf } =
     props;
@@ -367,6 +479,12 @@ const styles = StyleSheet.create({
   container: {
     display: "flex",
     gap: 12,
+  },
+  // sits under the title in a tile's text block, so it lines up with it
+  // rather than centring like a person tile's label
+  partsLabel: {
+    fontSize: 12,
+    color: Colors.zinc[400],
   },
   playthroughContainer: {
     display: "flex",

--- a/src/components/screens/BookScreen.tsx
+++ b/src/components/screens/BookScreen.tsx
@@ -4,7 +4,7 @@ import Animated from "react-native-reanimated";
 import { FadeInOnMount } from "@/components/FadeInOnMount";
 import { ScrollHandler } from "@/components/FadingHeader";
 import { Header } from "@/components/screens/book-screen/Header";
-import { Tile } from "@/components/Tiles";
+import { EditionTile } from "@/components/Tiles";
 import { PAGE_SIZE } from "@/constants";
 import { getBookDetails, useLibraryData } from "@/services/library-service";
 import { Session } from "@/types/session";
@@ -15,8 +15,8 @@ type BookScreenProps = {
   scrollHandler?: ScrollHandler;
 };
 
-// NOTE: Media is hard-limited to PAGE_SIZE. This could be a paginated list,
-// but it seems really unlikely that a book will have that many media.
+// NOTE: Editions are hard-limited to PAGE_SIZE. This could be a paginated
+// list, but it seems really unlikely that a book will have that many.
 export function BookScreen({
   bookId,
   session,
@@ -33,8 +33,8 @@ export function BookScreen({
       showsVerticalScrollIndicator={false}
       onScroll={scrollHandler}
       scrollEventThrottle={16}
-      data={book.media}
-      keyExtractor={(item) => item.id}
+      data={book.editions}
+      keyExtractor={(item) => item.representative.id}
       numColumns={2}
       ListHeaderComponent={() => (
         <FadeInOnMount>
@@ -44,7 +44,7 @@ export function BookScreen({
       renderItem={({ item }) => {
         return (
           <FadeInOnMount style={styles.tile}>
-            <Tile media={[item]} book={book} />
+            <EditionTile edition={item} book={book} />
           </FadeInOnMount>
         );
       }}

--- a/src/components/screens/library-screen/FullLibrary.tsx
+++ b/src/components/screens/library-screen/FullLibrary.tsx
@@ -6,7 +6,7 @@ import FontAwesome6 from "@expo/vector-icons/FontAwesome6";
 
 import { ScrollHandler } from "@/components/FadingHeader";
 import { Loading } from "@/components/Loading";
-import { MediaTile } from "@/components/Tiles";
+import { EditionTile } from "@/components/Tiles";
 import { PAGE_SIZE, PLAYER_HEIGHT, TAB_BAR_BASE_HEIGHT } from "@/constants";
 import {
   getMediaPage,
@@ -47,7 +47,8 @@ export function FullLibrary({
 
   const getPage = (pageSize: number, cursor: Date | undefined) =>
     getMediaPage(session, pageSize, cursor);
-  const getCursor = (item: { insertedAt: Date }) => item.insertedAt;
+  const getCursor = (item: { representative: { insertedAt: Date } }) =>
+    item.representative.insertedAt;
   const page = usePaginatedLibraryData(PAGE_SIZE, getPage, getCursor);
   const { items: media, hasMore, loadMore } = page;
   const { refreshing, onRefresh } = usePullToRefresh(session);
@@ -103,11 +104,11 @@ export function FullLibrary({
       onScroll={scrollHandler}
       scrollEventThrottle={16}
       data={media}
-      keyExtractor={(item) => item.id}
+      keyExtractor={(item) => item.representative.id}
       numColumns={NUM_COLUMNS}
       renderItem={({ item }) => (
         <View style={styles.tile}>
-          <MediaTile media={item} />
+          <EditionTile edition={item} book={item.representative.book} />
         </View>
       )}
       // No getItemLayout: tile rows are not a fixed height (the text block

--- a/src/components/screens/media-screen/OtherEditions.tsx
+++ b/src/components/screens/media-screen/OtherEditions.tsx
@@ -3,7 +3,7 @@ import { router } from "expo-router";
 
 import { HeaderButton } from "@/components/HeaderButton";
 import { SeeAllTile } from "@/components/SeeAllTile";
-import { MediaTile } from "@/components/Tiles";
+import { EditionTile } from "@/components/Tiles";
 import {
   HORIZONTAL_LIST_LIMIT,
   HORIZONTAL_TILE_SPACING,
@@ -30,7 +30,7 @@ export function OtherEditions(props: OtherEditionsProps) {
   );
 
   if (!book) return null;
-  if (!book.media[0]) return null;
+  if (!book.editions[0]) return null;
 
   const navigateToBook = () => {
     router.navigate({
@@ -43,7 +43,7 @@ export function OtherEditions(props: OtherEditionsProps) {
   };
 
   const tileSize = screenWidth / HORIZONTAL_TILE_WIDTH_RATIO;
-  const hasMore = book.media.length === HORIZONTAL_LIST_LIMIT;
+  const hasMore = book.editions.length === HORIZONTAL_LIST_LIMIT;
 
   return (
     <View style={styles.container}>
@@ -56,8 +56,8 @@ export function OtherEditions(props: OtherEditionsProps) {
       </View>
       <FlatList
         style={styles.list}
-        data={book.media}
-        keyExtractor={(item) => item.id}
+        data={book.editions}
+        keyExtractor={(item) => item.representative.id}
         horizontal={true}
         showsHorizontalScrollIndicator={false}
         snapToInterval={tileSize + HORIZONTAL_TILE_SPACING}
@@ -76,7 +76,7 @@ export function OtherEditions(props: OtherEditionsProps) {
         renderItem={({ item }) => {
           return (
             <View style={[styles.tile, { width: tileSize }]}>
-              <MediaTile media={{ ...item, book: book }} />
+              <EditionTile edition={item} book={book} />
             </View>
           );
         }}

--- a/src/components/screens/search-screen/SearchResults.tsx
+++ b/src/components/screens/search-screen/SearchResults.tsx
@@ -9,7 +9,7 @@ import Animated, {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import FontAwesome6 from "@expo/vector-icons/FontAwesome6";
 
-import { MediaTile } from "@/components/Tiles";
+import { EditionTile } from "@/components/Tiles";
 import { PAGE_SIZE, PLAYER_HEIGHT, TAB_BAR_BASE_HEIGHT } from "@/constants";
 import { getSearchedMedia, useLibraryData } from "@/services/library-service";
 import { useTrackPlayer } from "@/stores/track-player";
@@ -87,11 +87,11 @@ export function SearchResults(props: SearchResultsProps) {
       showsVerticalScrollIndicator={false}
       scrollEventThrottle={16}
       data={media}
-      keyExtractor={(item) => item.id}
+      keyExtractor={(item) => item.representative.id}
       numColumns={NUM_COLUMNS}
       renderItem={({ item }) => (
         <View style={styles.tile}>
-          <MediaTile media={item} />
+          <EditionTile edition={item} book={item.representative.book} />
         </View>
       )}
       // No getItemLayout: see FullLibrary — tile rows are not a fixed height,

--- a/src/db/library/__tests__/get-book-details.test.ts
+++ b/src/db/library/__tests__/get-book-details.test.ts
@@ -81,8 +81,8 @@ describe("getBookDetails", () => {
 
     const result = await getBookDetails(DEFAULT_TEST_SESSION, book.id, 10);
 
-    expect(result.media).toHaveLength(1);
-    expect(result.media[0]?.id).toBe(media.id);
+    expect(result.editions).toHaveLength(1);
+    expect(result.editions[0]?.representative.id).toBe(media.id);
   });
 
   it("returns media with narrators", async () => {
@@ -97,11 +97,13 @@ describe("getBookDetails", () => {
 
     const result = await getBookDetails(DEFAULT_TEST_SESSION, book.id, 10);
 
-    expect(result.media[0]?.narrators).toHaveLength(1);
-    expect(result.media[0]?.narrators[0]?.name).toBe("Stephen Fry");
+    expect(result.editions[0]?.representative.narrators).toHaveLength(1);
+    expect(result.editions[0]?.representative.narrators[0]?.name).toBe(
+      "Stephen Fry",
+    );
   });
 
-  it("respects media limit", async () => {
+  it("respects the edition limit", async () => {
     const db = getDb();
 
     const book = await createBook(db);
@@ -111,7 +113,7 @@ describe("getBookDetails", () => {
 
     const result = await getBookDetails(DEFAULT_TEST_SESSION, book.id, 2);
 
-    expect(result.media).toHaveLength(2);
+    expect(result.editions).toHaveLength(2);
   });
 
   it("includes download thumbnails when media is downloaded", async () => {
@@ -134,9 +136,9 @@ describe("getBookDetails", () => {
 
     const result = await getBookDetails(DEFAULT_TEST_SESSION, book.id, 10);
 
-    expect(result.media[0]?.download?.thumbnails?.thumbhash).toBe(
-      "downloadhash",
-    );
+    expect(
+      result.editions[0]?.representative.download?.thumbnails?.thumbhash,
+    ).toBe("downloadhash");
   });
 
   it("only returns book for the current session URL", async () => {

--- a/src/db/library/__tests__/get-book-other-editions.test.ts
+++ b/src/db/library/__tests__/get-book-other-editions.test.ts
@@ -10,6 +10,7 @@ import {
   createDownload,
   createMedia,
   createMediaNarrator,
+  createRecordingGroup,
   DEFAULT_TEST_SESSION,
 } from "@test/factories";
 
@@ -80,8 +81,8 @@ describe("getBookOtherEditions", () => {
     );
 
     expect(result).not.toBeNull();
-    expect(result?.media).toHaveLength(1);
-    expect(result?.media[0]?.id).toBe(media2.id);
+    expect(result?.editions).toHaveLength(1);
+    expect(result?.editions[0]?.representative.id).toBe(media2.id);
   });
 
   it("excludes the current media from results", async () => {
@@ -99,10 +100,11 @@ describe("getBookOtherEditions", () => {
       10,
     );
 
-    expect(result?.media).toHaveLength(2);
-    expect(result?.media.map((m) => m.id)).not.toContain(media1.id);
-    expect(result?.media.map((m) => m.id)).toContain(media2.id);
-    expect(result?.media.map((m) => m.id)).toContain(media3.id);
+    const editionIds = result?.editions.map((e) => e.representative.id);
+    expect(result?.editions).toHaveLength(2);
+    expect(editionIds).not.toContain(media1.id);
+    expect(editionIds).toContain(media2.id);
+    expect(editionIds).toContain(media3.id);
   });
 
   it("includes narrators for each edition", async () => {
@@ -123,8 +125,10 @@ describe("getBookOtherEditions", () => {
       10,
     );
 
-    expect(result?.media[0]?.narrators).toHaveLength(1);
-    expect(result?.media[0]?.narrators[0]?.name).toBe("Rosamund Pike");
+    expect(result?.editions[0]?.representative.narrators).toHaveLength(1);
+    expect(result?.editions[0]?.representative.narrators[0]?.name).toBe(
+      "Rosamund Pike",
+    );
   });
 
   it("respects the limit parameter", async () => {
@@ -143,7 +147,7 @@ describe("getBookOtherEditions", () => {
       2,
     );
 
-    expect(result?.media).toHaveLength(2);
+    expect(result?.editions).toHaveLength(2);
   });
 
   it("includes download thumbnails when downloaded", async () => {
@@ -172,9 +176,121 @@ describe("getBookOtherEditions", () => {
       10,
     );
 
-    expect(result?.media[0]?.download?.thumbnails?.thumbhash).toBe(
-      "downloadhash",
+    expect(
+      result?.editions[0]?.representative.download?.thumbnails?.thumbhash,
+    ).toBe("downloadhash");
+  });
+
+  describe("when the reader is on a part of a set", () => {
+    it("leaves out the rest of the reader's own set", async () => {
+      const db = getDb();
+
+      const book = await createBook(db);
+      const set = await createRecordingGroup(db, {
+        bookId: book.id,
+        partsTotal: 3,
+      });
+      const parts = [];
+      for (let n = 1; n <= 3; n++) {
+        parts.push(
+          await createMedia(db, {
+            bookId: book.id,
+            recordingGroupId: set.id,
+            partNumber: n,
+          }),
+        );
+      }
+      const otherEdition = await createMedia(db, { bookId: book.id });
+
+      const result = await getBookOtherEditions(
+        DEFAULT_TEST_SESSION,
+        { ...makeMediaHeaderInfo(parts[0]!.id, book.id, book.title), set },
+        10,
+      );
+
+      expect(result?.editions).toHaveLength(1);
+      expect(result?.editions[0]?.representative.id).toBe(otherEdition.id);
+    });
+
+    it("leaves out a lone sibling rather than calling it an edition", async () => {
+      // the trap: with one part left over, dropping only the current recording
+      // leaves a one-part set, which collapses to a single edition and
+      // presents itself as a rival edition of the book
+      const db = getDb();
+
+      const book = await createBook(db);
+      const set = await createRecordingGroup(db, {
+        bookId: book.id,
+        partsTotal: 2,
+      });
+      const part1 = await createMedia(db, {
+        bookId: book.id,
+        recordingGroupId: set.id,
+        partNumber: 1,
+      });
+      await createMedia(db, {
+        bookId: book.id,
+        recordingGroupId: set.id,
+        partNumber: 2,
+      });
+
+      const result = await getBookOtherEditions(
+        DEFAULT_TEST_SESSION,
+        { ...makeMediaHeaderInfo(part1.id, book.id, book.title), set },
+        10,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("collapses a rival set into one stacked edition", async () => {
+      const db = getDb();
+
+      const book = await createBook(db);
+      const rival = await createRecordingGroup(db, {
+        bookId: book.id,
+        partsTotal: 3,
+      });
+      const rivalParts = [];
+      for (let n = 1; n <= 3; n++) {
+        rivalParts.push(
+          await createMedia(db, {
+            bookId: book.id,
+            recordingGroupId: rival.id,
+            partNumber: n,
+          }),
+        );
+      }
+      const current = await createMedia(db, { bookId: book.id });
+
+      const result = await getBookOtherEditions(
+        DEFAULT_TEST_SESSION,
+        makeMediaHeaderInfo(current.id, book.id, book.title),
+        10,
+      );
+
+      expect(result?.editions).toHaveLength(1);
+      expect(result?.editions[0]?.kind).toBe("set");
+      expect(result?.editions[0]?.media.map((m) => m.id)).toEqual(
+        rivalParts.map((p) => p.id),
+      );
+    });
+  });
+
+  it("leaves out recordings that are not ready", async () => {
+    const db = getDb();
+
+    const book = await createBook(db);
+    const current = await createMedia(db, { bookId: book.id });
+    await createMedia(db, { bookId: book.id, status: "processing" });
+
+    const result = await getBookOtherEditions(
+      DEFAULT_TEST_SESSION,
+      makeMediaHeaderInfo(current.id, book.id, book.title),
+      10,
     );
+
+    expect(result).toBeNull();
   });
 
   it("only returns editions for the current session URL", async () => {

--- a/src/db/library/__tests__/get-media-page.test.ts
+++ b/src/db/library/__tests__/get-media-page.test.ts
@@ -10,6 +10,7 @@ import {
   createDownload,
   createMedia,
   createMediaNarrator,
+  createRecordingGroup,
   createSeries,
   createSeriesBook,
   DEFAULT_TEST_SESSION,
@@ -36,8 +37,8 @@ describe("getMediaPage", () => {
     const result = await getMediaPage(DEFAULT_TEST_SESSION, 10);
 
     expect(result).toHaveLength(1);
-    expect(result[0]?.id).toBe(media.id);
-    expect(result[0]?.book.title).toBe("Pride and Prejudice");
+    expect(result[0]?.representative.id).toBe(media.id);
+    expect(result[0]?.representative.book.title).toBe("Pride and Prejudice");
   });
 
   it("includes book authors", async () => {
@@ -52,8 +53,8 @@ describe("getMediaPage", () => {
 
     const result = await getMediaPage(DEFAULT_TEST_SESSION, 10);
 
-    expect(result[0]?.book.authors).toHaveLength(1);
-    expect(result[0]?.book.authors[0]?.name).toBe("Jane Austen");
+    expect(result[0]?.representative.book.authors).toHaveLength(1);
+    expect(result[0]?.representative.book.authors[0]?.name).toBe("Jane Austen");
   });
 
   it("includes media narrators", async () => {
@@ -68,8 +69,8 @@ describe("getMediaPage", () => {
 
     const result = await getMediaPage(DEFAULT_TEST_SESSION, 10);
 
-    expect(result[0]?.narrators).toHaveLength(1);
-    expect(result[0]?.narrators[0]?.name).toBe("Rosamund Pike");
+    expect(result[0]?.representative.narrators).toHaveLength(1);
+    expect(result[0]?.representative.narrators[0]?.name).toBe("Rosamund Pike");
   });
 
   it("includes download thumbnails when media is downloaded", async () => {
@@ -92,7 +93,9 @@ describe("getMediaPage", () => {
 
     const result = await getMediaPage(DEFAULT_TEST_SESSION, 10);
 
-    expect(result[0]?.download?.thumbnails?.thumbhash).toBe("downloadhash");
+    expect(result[0]?.representative.download?.thumbnails?.thumbhash).toBe(
+      "downloadhash",
+    );
   });
 
   it("only returns media with status 'ready'", async () => {
@@ -130,7 +133,7 @@ describe("getMediaPage", () => {
 
     const result = await getMediaPage(DEFAULT_TEST_SESSION, 10);
 
-    expect(result[0]?.id).toBe(newerMedia.id);
+    expect(result[0]?.representative.id).toBe(newerMedia.id);
   });
 
   it("respects the limit parameter", async () => {
@@ -193,6 +196,107 @@ describe("getMediaPage", () => {
 
     expect(result).toEqual([]);
   });
+
+  describe("sets", () => {
+    async function createSet(
+      db: ReturnType<typeof getDb>,
+      partCount: number,
+      { readyParts = partCount }: { readyParts?: number } = {},
+    ) {
+      const book = await createBook(db, { title: "The Way of Kings" });
+      const set = await createRecordingGroup(db, {
+        bookId: book.id,
+        partsTotal: partCount,
+      });
+      const parts = [];
+      for (let n = 1; n <= partCount; n++) {
+        parts.push(
+          await createMedia(db, {
+            bookId: book.id,
+            recordingGroupId: set.id,
+            partNumber: n,
+            status: n <= readyParts ? "ready" : "processing",
+          }),
+        );
+      }
+      return { book, set, parts };
+    }
+
+    it("collapses a set to one entry", async () => {
+      const db = getDb();
+      const { parts } = await createSet(db, 3);
+
+      const result = await getMediaPage(DEFAULT_TEST_SESSION, 10);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.kind).toBe("set");
+      expect(result[0]?.representative.id).toBe(parts[0]!.id);
+    });
+
+    it("stacks the set's parts in part order, first part in front", async () => {
+      const db = getDb();
+      const { parts } = await createSet(db, 3);
+
+      const result = await getMediaPage(DEFAULT_TEST_SESSION, 10);
+
+      expect(result[0]?.media.map((m) => m.id)).toEqual(parts.map((p) => p.id));
+    });
+
+    it("represents a set by its first *ready* part", async () => {
+      const db = getDb();
+      const book = await createBook(db);
+      const set = await createRecordingGroup(db, { bookId: book.id });
+      await createMedia(db, {
+        bookId: book.id,
+        recordingGroupId: set.id,
+        partNumber: 1,
+        status: "processing",
+      });
+      const readyPart = await createMedia(db, {
+        bookId: book.id,
+        recordingGroupId: set.id,
+        partNumber: 2,
+      });
+
+      const result = await getMediaPage(DEFAULT_TEST_SESSION, 10);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.representative.id).toBe(readyPart.id);
+    });
+
+    it("presents a set with one ready part as a single recording", async () => {
+      const db = getDb();
+      const { parts } = await createSet(db, 3, { readyParts: 1 });
+
+      const result = await getMediaPage(DEFAULT_TEST_SESSION, 10);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.kind).toBe("single");
+      expect(result[0]?.media.map((m) => m.id)).toEqual([parts[0]!.id]);
+    });
+
+    it("keeps a set and a standalone recording of the same book apart", async () => {
+      const db = getDb();
+      const { book } = await createSet(db, 2);
+      const standalone = await createMedia(db, { bookId: book.id });
+
+      const result = await getMediaPage(DEFAULT_TEST_SESSION, 10);
+
+      expect(result).toHaveLength(2);
+      expect(result.map((e) => e.representative.id)).toContain(standalone.id);
+    });
+
+    it("fills a page with entries, not with parts", async () => {
+      const db = getDb();
+      await createSet(db, 3);
+      await createSet(db, 3);
+      await createSet(db, 3);
+
+      const result = await getMediaPage(DEFAULT_TEST_SESSION, 2);
+
+      expect(result).toHaveLength(2);
+    });
+  });
 });
 
 describe("getSearchedMedia", () => {
@@ -236,7 +340,7 @@ describe("getSearchedMedia", () => {
     const result = await getSearchedMedia(DEFAULT_TEST_SESSION, 10, "Pride");
 
     expect(result).toHaveLength(1);
-    expect(result[0]?.book.title).toBe("Pride and Prejudice");
+    expect(result[0]?.representative.book.title).toBe("Pride and Prejudice");
   });
 
   it("finds media by author name", async () => {
@@ -256,7 +360,7 @@ describe("getSearchedMedia", () => {
     const result = await getSearchedMedia(DEFAULT_TEST_SESSION, 10, "Austen");
 
     expect(result).toHaveLength(1);
-    expect(result[0]?.book.authors[0]?.name).toBe("Jane Austen");
+    expect(result[0]?.representative.book.authors[0]?.name).toBe("Jane Austen");
   });
 
   it("finds media by narrator name", async () => {
@@ -276,7 +380,7 @@ describe("getSearchedMedia", () => {
     const result = await getSearchedMedia(DEFAULT_TEST_SESSION, 10, "Rosamund");
 
     expect(result).toHaveLength(1);
-    expect(result[0]?.narrators[0]?.name).toBe("Rosamund Pike");
+    expect(result[0]?.representative.narrators[0]?.name).toBe("Rosamund Pike");
   });
 
   it("finds media by series name", async () => {
@@ -298,7 +402,7 @@ describe("getSearchedMedia", () => {
     const result = await getSearchedMedia(DEFAULT_TEST_SESSION, 10, "Potter");
 
     expect(result).toHaveLength(1);
-    expect(result[0]?.book.title).toBe("Philosopher's Stone");
+    expect(result[0]?.representative.book.title).toBe("Philosopher's Stone");
   });
 
   it("returns distinct results for multiple matches", async () => {
@@ -374,7 +478,7 @@ describe("getSearchedMedia", () => {
     const result = await getSearchedMedia(DEFAULT_TEST_SESSION, 10, "Book");
 
     expect(result).toHaveLength(1);
-    expect(result[0]?.book.title).toBe("Ready Book");
+    expect(result[0]?.representative.book.title).toBe("Ready Book");
   });
 
   it("only returns media for the current session URL", async () => {

--- a/src/db/library/get-book-details.ts
+++ b/src/db/library/get-book-details.ts
@@ -1,11 +1,13 @@
-import { and, asc, desc, eq, sql } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 
 import { getDb } from "@/db/db";
 import * as schema from "@/db/schema";
 import { Session } from "@/types/session";
+import { toEditions } from "@/utils/editions";
 import { requireValue } from "@/utils/require-value";
 
 import {
+  getEditionMediaForBook,
   getNarratorsForMedia,
   getPlaythroughStatusesForMedia,
   getSavedForLaterStatusForMedia,
@@ -13,14 +15,20 @@ import {
 
 export type BookDetails = Awaited<ReturnType<typeof getBookDetails>>;
 
+/**
+ * A book and its editions.
+ *
+ * The book screen is where editions are shown as themselves, so a set arrives
+ * whole — one tile stacking its parts — rather than as loose recordings.
+ */
 export async function getBookDetails(
   session: Session,
   bookId: string,
-  mediaLimit: number,
+  editionLimit: number,
 ) {
   const book = await getBook(session, bookId);
   const authorsForBook = await getAuthorsForBook(session, bookId);
-  const mediaForBook = await getMediaForBook(session, bookId, mediaLimit);
+  const mediaForBook = await getEditionMediaForBook(session, bookId);
 
   const mediaIds = mediaForBook.map((m) => m.id);
   const narratorsForMedia = await getNarratorsForMedia(session, mediaIds);
@@ -30,15 +38,17 @@ export async function getBookDetails(
   );
   const savedForLater = await getSavedForLaterStatusForMedia(session, mediaIds);
 
+  const media = mediaForBook.map((media) => ({
+    ...media,
+    narrators: narratorsForMedia[media.id] ?? [],
+    playthroughStatus: playthroughStatuses[media.id] ?? null,
+    isOnSavedShelf: savedForLater.has(media.id),
+  }));
+
   return {
     ...book,
     authors: authorsForBook,
-    media: mediaForBook.map((media) => ({
-      ...media,
-      narrators: narratorsForMedia[media.id] ?? [],
-      playthroughStatus: playthroughStatuses[media.id] ?? null,
-      isOnSavedShelf: savedForLater.has(media.id),
-    })),
+    editions: toEditions(media).slice(0, editionLimit),
   };
 }
 
@@ -76,42 +86,4 @@ async function getAuthorsForBook(session: Session, bookId: string) {
       ),
     )
     .orderBy(asc(schema.bookAuthors.insertedAt));
-}
-
-async function getMediaForBook(
-  session: Session,
-  bookId: string,
-  limit: number,
-) {
-  return getDb()
-    .select({
-      id: schema.media.id,
-      title: schema.media.title,
-      thumbnails: schema.media.thumbnails,
-      download: {
-        thumbnails: schema.downloads.thumbnails,
-      },
-    })
-    .from(schema.media)
-    .leftJoin(
-      schema.downloads,
-      and(
-        eq(schema.downloads.url, schema.media.url),
-        eq(schema.downloads.mediaId, schema.media.id),
-      ),
-    )
-    .innerJoin(
-      schema.books,
-      and(
-        eq(schema.books.url, schema.media.url),
-        eq(schema.books.id, schema.media.bookId),
-      ),
-    )
-    .where(
-      and(eq(schema.media.url, session.url), eq(schema.media.bookId, bookId)),
-    )
-    .orderBy(
-      desc(sql`COALESCE(${schema.media.published}, ${schema.books.published})`),
-    )
-    .limit(limit);
 }

--- a/src/db/library/get-book-other-editions.ts
+++ b/src/db/library/get-book-other-editions.ts
@@ -1,11 +1,9 @@
-import { and, desc, eq, ne, sql } from "drizzle-orm";
-
-import { getDb } from "@/db/db";
-import * as schema from "@/db/schema";
 import { Session } from "@/types/session";
+import { toEditions } from "@/utils/editions";
 
 import { MediaHeaderInfo } from "./get-media-header-info";
 import {
+  getEditionMediaForBook,
   getNarratorsForMedia,
   getPlaythroughStatusesForMedia,
   getSavedForLaterStatusForMedia,
@@ -15,17 +13,29 @@ export type BookOtherEditions = Awaited<
   ReturnType<typeof getBookOtherEditions>
 >;
 
+/**
+ * The book's other editions — true alternates only.
+ *
+ * The whole of the reader's own set is excluded, not just the recording they
+ * are looking at: its remaining parts belong to "the rest of this set" above,
+ * and a single leftover sibling would otherwise collapse to a lone edition and
+ * present itself as an alternate. What is left collapses the usual way, so a
+ * rival set arrives as one stacked tile rather than as loose parts.
+ */
 export async function getBookOtherEditions(
   session: Session,
   media: MediaHeaderInfo,
   limit: number,
 ) {
   const { book } = media;
-  const otherMedia = await getOtherMedia(session, book.id, media.id, limit);
+  const otherMedia = await getEditionMediaForBook(session, book.id, {
+    excludeSetId: media.set?.id,
+  });
+  const rest = otherMedia.filter((other) => other.id !== media.id);
 
-  if (otherMedia.length === 0) return null;
+  if (rest.length === 0) return null;
 
-  const mediaIds = otherMedia.map((m) => m.id);
+  const mediaIds = rest.map((m) => m.id);
   const narratorsForMedia = await getNarratorsForMedia(session, mediaIds);
   const playthroughStatuses = await getPlaythroughStatusesForMedia(
     session,
@@ -33,56 +43,12 @@ export async function getBookOtherEditions(
   );
   const savedForLater = await getSavedForLaterStatusForMedia(session, mediaIds);
 
-  return {
-    ...book,
-    media: otherMedia.map((media) => ({
-      ...media,
-      narrators: narratorsForMedia[media.id] ?? [],
-      playthroughStatus: playthroughStatuses[media.id] ?? null,
-      isOnSavedShelf: savedForLater.has(media.id),
-    })),
-  };
-}
+  const withDetails = rest.map((media) => ({
+    ...media,
+    narrators: narratorsForMedia[media.id] ?? [],
+    playthroughStatus: playthroughStatuses[media.id] ?? null,
+    isOnSavedShelf: savedForLater.has(media.id),
+  }));
 
-async function getOtherMedia(
-  session: Session,
-  bookId: string,
-  withoutMediaId: string,
-  limit: number,
-) {
-  return getDb()
-    .select({
-      id: schema.media.id,
-      title: schema.media.title,
-      thumbnails: schema.media.thumbnails,
-      download: {
-        thumbnails: schema.downloads.thumbnails,
-      },
-    })
-    .from(schema.media)
-    .leftJoin(
-      schema.downloads,
-      and(
-        eq(schema.downloads.url, schema.media.url),
-        eq(schema.downloads.mediaId, schema.media.id),
-      ),
-    )
-    .innerJoin(
-      schema.books,
-      and(
-        eq(schema.books.url, schema.media.url),
-        eq(schema.books.id, schema.media.bookId),
-      ),
-    )
-    .where(
-      and(
-        eq(schema.media.url, session.url),
-        eq(schema.media.bookId, bookId),
-        ne(schema.media.id, withoutMediaId),
-      ),
-    )
-    .orderBy(
-      desc(sql`COALESCE(${schema.media.published}, ${schema.books.published})`),
-    )
-    .limit(limit);
+  return { ...book, editions: toEditions(withDetails).slice(0, limit) };
 }

--- a/src/db/library/get-media-by-narrator-page.ts
+++ b/src/db/library/get-media-by-narrator-page.ts
@@ -91,6 +91,7 @@ async function getMedia(
     .where(
       and(
         eq(schema.mediaNarrators.url, session.url),
+        eq(schema.media.status, "ready"),
         eq(schema.mediaNarrators.narratorId, narratorId),
         publishedBefore
           ? sql`${publishedExpr} < ${publishedBefore}`

--- a/src/db/library/get-media-by-narrators.ts
+++ b/src/db/library/get-media-by-narrators.ts
@@ -124,6 +124,7 @@ async function getMediaForNarrator(
     .where(
       and(
         eq(schema.mediaNarrators.url, session.url),
+        eq(schema.media.status, "ready"),
         eq(schema.mediaNarrators.narratorId, narratorId),
       ),
     )

--- a/src/db/library/get-media-page.ts
+++ b/src/db/library/get-media-page.ts
@@ -1,8 +1,10 @@
-import { and, desc, eq, like, lt, or, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, like, lt, or, sql } from "drizzle-orm";
 
 import { getDb } from "@/db/db";
 import * as schema from "@/db/schema";
+import { DownloadedThumbnails, Thumbnails } from "@/db/schema";
 import { Session } from "@/types/session";
+import { byPartOrder } from "@/utils/editions";
 
 import {
   getAuthorsForBooks,
@@ -22,28 +24,173 @@ export async function getMediaPage(
 ) {
   const media = await recentMedia(session, limit, insertedBefore);
 
+  return withEditionDetails(session, media);
+}
+
+/**
+ * Turns representative rows into editions ready to render.
+ *
+ * The rows arriving here are already collapsed — one per edition — so this
+ * fills in what a tile needs around them: the book's authors, the
+ * representative's own details, and, for a row standing in for a set, the rest
+ * of that set's parts so the tile can stack them.
+ */
+async function withEditionDetails<T extends RepresentativeRow>(
+  session: Session,
+  media: T[],
+) {
   const bookIds = media.map((m) => m.book.id);
   const authorsForBooks = await getAuthorsForBooks(session, bookIds);
 
-  const mediaIds = media.map((m) => m.id);
-  const narratorsForMedia = await getNarratorsForMedia(session, mediaIds);
-  const playthroughStatuses = await getPlaythroughStatusesForMedia(
-    session,
-    mediaIds,
-  );
-  const savedForLater = await getSavedForLaterStatusForMedia(session, mediaIds);
+  const setIds = media
+    .map((m) => m.recordingGroupId)
+    .filter((id): id is string => id !== null);
+  const partsForSets = await getPartsForSets(session, setIds);
 
-  return media.map((media) => ({
-    ...media,
-    book: {
-      ...media.book,
-      authors: authorsForBooks[media.book.id] || [],
-    },
-    narrators: narratorsForMedia[media.id] || [],
-    playthroughStatus: playthroughStatuses[media.id] ?? null,
-    isOnSavedShelf: savedForLater.has(media.id),
-  }));
+  // A set's badges answer for the whole set, so every part counts, not just
+  // the one standing at the front of the stack.
+  const mediaIds = media.map((m) => m.id);
+  const partIds = Object.values(partsForSets).flatMap((set) =>
+    set.parts.map((part) => part.id),
+  );
+  const narratorsForMedia = await getNarratorsForMedia(session, mediaIds);
+  const playthroughStatuses = await getPlaythroughStatusesForMedia(session, [
+    ...mediaIds,
+    ...partIds,
+  ]);
+  const savedForLater = await getSavedForLaterStatusForMedia(session, [
+    ...mediaIds,
+    ...partIds,
+  ]);
+
+  return media.map((media) => {
+    const found = media.recordingGroupId
+      ? partsForSets[media.recordingGroupId]
+      : undefined;
+    // A set whose other parts are not ready has nothing to stack, and a
+    // one-part set is not a set -- it presents as the single recording it is.
+    const set = found && found.parts.length >= 2 ? found : undefined;
+
+    const representative = {
+      ...media,
+      book: {
+        ...media.book,
+        authors: authorsForBooks[media.book.id] || [],
+      },
+      narrators: narratorsForMedia[media.id] || [],
+      playthroughStatus: playthroughStatuses[media.id] ?? null,
+      isOnSavedShelf: savedForLater.has(media.id),
+      set: set?.set ?? null,
+    };
+
+    if (!set) {
+      return {
+        kind: "single" as const,
+        media: [representative],
+        representative,
+        setId: null,
+      };
+    }
+
+    return {
+      kind: "set" as const,
+      // the representative carries details the bare part rows lack, so it
+      // stands in for its own part rather than being fetched twice
+      media: set.parts.map((part) =>
+        part.id === representative.id
+          ? representative
+          : {
+              ...representative,
+              ...part,
+              set: set.set,
+              narrators: [],
+              playthroughStatus: playthroughStatuses[part.id] ?? null,
+              isOnSavedShelf: savedForLater.has(part.id),
+            },
+      ),
+      representative,
+      setId: set.set.id,
+    };
+  });
 }
+
+type RepresentativeRow = {
+  id: string;
+  recordingGroupId: string | null;
+  book: { id: string; title: string };
+};
+
+/** Every ready part of the given sets, in part order, with the set itself. */
+async function getPartsForSets(session: Session, setIds: string[]) {
+  if (setIds.length === 0) return {};
+
+  const rows = await getDb()
+    .select({
+      id: schema.media.id,
+      partNumber: schema.media.partNumber,
+      published: schema.media.published,
+      recordingGroupId: schema.media.recordingGroupId,
+      thumbnails: schema.media.thumbnails,
+      download: { thumbnails: schema.downloads.thumbnails },
+      set: {
+        id: schema.recordingGroups.id,
+        partsTotal: schema.recordingGroups.partsTotal,
+        partWord: schema.recordingGroups.partWord,
+        partWordPlural: schema.recordingGroups.partWordPlural,
+      },
+    })
+    .from(schema.media)
+    .innerJoin(
+      schema.recordingGroups,
+      and(
+        eq(schema.recordingGroups.url, schema.media.url),
+        eq(schema.recordingGroups.id, schema.media.recordingGroupId),
+      ),
+    )
+    .leftJoin(
+      schema.downloads,
+      and(
+        eq(schema.downloads.url, schema.media.url),
+        eq(schema.downloads.mediaId, schema.media.id),
+      ),
+    )
+    .where(
+      and(
+        eq(schema.media.url, session.url),
+        eq(schema.media.status, "ready"),
+        inArray(schema.media.recordingGroupId, setIds),
+      ),
+    );
+
+  const bySet: Record<string, { set: SetRow; parts: PartRow[] }> = {};
+
+  for (const { set, ...part } of rows) {
+    const entry = (bySet[set.id] ??= { set, parts: [] });
+    entry.parts.push(part);
+  }
+
+  for (const entry of Object.values(bySet)) {
+    entry.parts.sort(byPartOrder);
+  }
+
+  return bySet;
+}
+
+type SetRow = {
+  id: string;
+  partsTotal: number | null;
+  partWord: string | null;
+  partWordPlural: string | null;
+};
+
+type PartRow = {
+  id: string;
+  partNumber: number | null;
+  published: Date | null;
+  recordingGroupId: string | null;
+  thumbnails: Thumbnails | null;
+  download: { thumbnails: DownloadedThumbnails | null } | null;
+};
 
 export async function getSearchedMedia(
   session: Session,
@@ -52,29 +199,18 @@ export async function getSearchedMedia(
 ) {
   const media = await searchMedia(session, limit, searchQuery);
 
-  const bookIds = media.map((m) => m.book.id);
-  const authorsForBooks = await getAuthorsForBooks(session, bookIds);
-
-  const mediaIds = media.map((m) => m.id);
-  const narratorsForMedia = await getNarratorsForMedia(session, mediaIds);
-  const playthroughStatuses = await getPlaythroughStatusesForMedia(
-    session,
-    mediaIds,
-  );
-  const savedForLater = await getSavedForLaterStatusForMedia(session, mediaIds);
-
-  return media.map((media) => ({
-    ...media,
-    book: {
-      ...media.book,
-      authors: authorsForBooks[media.book.id] || [],
-    },
-    narrators: narratorsForMedia[media.id] || [],
-    playthroughStatus: playthroughStatuses[media.id] ?? null,
-    isOnSavedShelf: savedForLater.has(media.id),
-  }));
+  return withEditionDetails(session, media);
 }
 
+/**
+ * The library listing collapses a set to a single entry.
+ *
+ * The collapse has to happen in SQL rather than after the fact: this list is
+ * paged, and grouping a page's worth of rows afterwards would leave pages of
+ * uneven length and could split a set across a page boundary. Only the first
+ * ready part of each set survives the filter, which is the same representative
+ * `toEditions` would have picked.
+ */
 async function recentMedia(
   session: Session,
   limit: number,
@@ -86,6 +222,9 @@ async function recentMedia(
       title: schema.media.title,
       thumbnails: schema.media.thumbnails,
       insertedAt: schema.media.insertedAt,
+      recordingGroupId: schema.media.recordingGroupId,
+      partNumber: schema.media.partNumber,
+      published: schema.media.published,
       book: {
         id: schema.books.id,
         title: schema.books.title,
@@ -113,6 +252,10 @@ async function recentMedia(
       and(
         eq(schema.media.url, session.url),
         eq(schema.media.status, "ready"),
+        or(
+          isNull(schema.media.recordingGroupId),
+          eq(schema.media.id, firstReadyPartOfSet),
+        ),
         insertedBefore
           ? lt(schema.media.insertedAt, insertedBefore)
           : undefined,
@@ -121,6 +264,17 @@ async function recentMedia(
     .orderBy(desc(schema.media.insertedAt))
     .limit(limit);
 }
+
+// Part number ascending, nulls last, then id -- spelled out rather than using
+// NULLS LAST so it does not depend on the SQLite version Expo ships.
+const firstReadyPartOfSet = sql`(
+  SELECT part.id FROM media part
+  WHERE part.url = ${schema.media.url}
+    AND part.recording_group_id = ${schema.media.recordingGroupId}
+    AND part.status = 'ready'
+  ORDER BY part.part_number IS NULL, part.part_number ASC, part.id ASC
+  LIMIT 1
+)`;
 
 async function searchMedia(
   session: Session,
@@ -132,6 +286,9 @@ async function searchMedia(
       id: schema.media.id,
       title: schema.media.title,
       thumbnails: schema.media.thumbnails,
+      recordingGroupId: schema.media.recordingGroupId,
+      partNumber: schema.media.partNumber,
+      published: schema.media.published,
       book: {
         id: schema.books.id,
         title: schema.books.title,
@@ -201,6 +358,12 @@ async function searchMedia(
       and(
         eq(schema.media.url, session.url),
         eq(schema.media.status, "ready"),
+        // one hit per set, same as the listing -- a set matching a search is
+        // one result, not one per part
+        or(
+          isNull(schema.media.recordingGroupId),
+          eq(schema.media.id, firstReadyPartOfSet),
+        ),
         or(
           like(schema.books.title, `%${searchQuery}%`),
           like(schema.authors.name, `%${searchQuery}%`),

--- a/src/db/library/get-other-media-by-narrators.ts
+++ b/src/db/library/get-other-media-by-narrators.ts
@@ -162,6 +162,7 @@ async function getMediaForNarrator(
     .where(
       and(
         eq(schema.narrators.url, session.url),
+        eq(schema.media.status, "ready"),
         eq(schema.narrators.id, narratorId),
         ne(schema.media.id, withoutMediaId),
       ),

--- a/src/db/library/get-set-parts.ts
+++ b/src/db/library/get-set-parts.ts
@@ -54,6 +54,7 @@ export async function getSetParts(
     .where(
       and(
         eq(schema.media.url, session.url),
+        eq(schema.media.status, "ready"),
         eq(schema.media.recordingGroupId, setId),
         excludeMediaId ? ne(schema.media.id, excludeMediaId) : undefined,
       ),

--- a/src/db/library/shared-queries.ts
+++ b/src/db/library/shared-queries.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
 
 import { getDb } from "@/db/db";
 import * as schema from "@/db/schema";
@@ -137,6 +137,75 @@ export async function getNarratorPeopleForMedia(
   );
 }
 
+/**
+ * Every ready recording of one book, with the set each belongs to, ready to
+ * be grouped into editions.
+ *
+ * Deliberately unlimited: a set has to arrive whole or it cannot be collapsed
+ * — a limit applied to recordings could cut a set in half and leave a stack
+ * claiming fewer parts than the set has. Callers limit *editions* instead,
+ * after grouping. A book has a handful of recordings, so this is cheap.
+ */
+export async function getEditionMediaForBook(
+  session: Session,
+  bookId: string,
+  { excludeSetId }: { excludeSetId?: string | null } = {},
+) {
+  const media = await getDb()
+    .select({
+      id: schema.media.id,
+      title: schema.media.title,
+      thumbnails: schema.media.thumbnails,
+      recordingGroupId: schema.media.recordingGroupId,
+      partNumber: schema.media.partNumber,
+      published: schema.media.published,
+      download: { thumbnails: schema.downloads.thumbnails },
+      set: {
+        id: schema.recordingGroups.id,
+        partsTotal: schema.recordingGroups.partsTotal,
+        partWord: schema.recordingGroups.partWord,
+        partWordPlural: schema.recordingGroups.partWordPlural,
+      },
+    })
+    .from(schema.media)
+    .leftJoin(
+      schema.downloads,
+      and(
+        eq(schema.downloads.url, schema.media.url),
+        eq(schema.downloads.mediaId, schema.media.id),
+      ),
+    )
+    .leftJoin(
+      schema.recordingGroups,
+      and(
+        eq(schema.recordingGroups.url, schema.media.url),
+        eq(schema.recordingGroups.id, schema.media.recordingGroupId),
+      ),
+    )
+    .where(
+      and(
+        eq(schema.media.url, session.url),
+        eq(schema.media.status, "ready"),
+        eq(schema.media.bookId, bookId),
+        excludeSetId
+          ? or(
+              isNull(schema.media.recordingGroupId),
+              ne(schema.media.recordingGroupId, excludeSetId),
+            )
+          : undefined,
+      ),
+    );
+
+  return media;
+}
+
+/**
+ * Every ready recording of the given books, for grouping into editions.
+ *
+ * Ordering is left to `toEditions`, which is the authority on it — sets have
+ * to be gathered before a book's recordings can be put in any meaningful
+ * order, and that cannot be expressed here.
+ */
 export async function getMediaForBooks(session: Session, bookIds: string[]) {
   if (bookIds.length === 0) return {};
 
@@ -145,6 +214,9 @@ export async function getMediaForBooks(session: Session, bookIds: string[]) {
       id: schema.media.id,
       bookId: schema.media.bookId,
       thumbnails: schema.media.thumbnails,
+      recordingGroupId: schema.media.recordingGroupId,
+      partNumber: schema.media.partNumber,
+      published: schema.media.published,
       download: { thumbnails: schema.downloads.thumbnails },
     })
     .from(schema.media)
@@ -155,21 +227,12 @@ export async function getMediaForBooks(session: Session, bookIds: string[]) {
         eq(schema.downloads.mediaId, schema.media.id),
       ),
     )
-    .innerJoin(
-      schema.books,
-      and(
-        eq(schema.books.url, schema.media.url),
-        eq(schema.books.id, schema.media.bookId),
-      ),
-    )
     .where(
       and(
         eq(schema.media.url, session.url),
+        eq(schema.media.status, "ready"),
         inArray(schema.media.bookId, bookIds),
       ),
-    )
-    .orderBy(
-      desc(sql`COALESCE(${schema.media.published}, ${schema.books.published})`),
     );
 
   return groupMapBy(

--- a/src/utils/__tests__/editions.test.ts
+++ b/src/utils/__tests__/editions.test.ts
@@ -1,0 +1,176 @@
+import {
+  Edition,
+  EditionMedia,
+  stackedRepresentatives,
+  toEditions,
+} from "@/utils/editions";
+
+function media(
+  id: string,
+  attrs: Partial<Omit<EditionMedia, "id">> = {},
+): EditionMedia {
+  return {
+    id,
+    recordingGroupId: attrs.recordingGroupId ?? null,
+    partNumber: attrs.partNumber ?? null,
+    published: attrs.published ?? null,
+  };
+}
+
+function ids(editions: Edition<EditionMedia>[]) {
+  return editions.map((edition) => edition.media.map((m) => m.id));
+}
+
+describe("toEditions", () => {
+  it("returns no editions for a book with nothing visible", () => {
+    expect(toEditions([])).toEqual([]);
+  });
+
+  it("makes one edition per standalone recording", () => {
+    const editions = toEditions([
+      media("a", { published: new Date("2020-01-01") }),
+      media("b", { published: new Date("2024-01-01") }),
+    ]);
+
+    expect(ids(editions)).toEqual([["b"], ["a"]]);
+    expect(editions.every((edition) => edition.kind === "single")).toBe(true);
+  });
+
+  it("gathers a set's parts into one edition, in part order", () => {
+    const editions = toEditions([
+      media("c", { recordingGroupId: "set", partNumber: 3 }),
+      media("a", { recordingGroupId: "set", partNumber: 1 }),
+      media("b", { recordingGroupId: "set", partNumber: 2 }),
+    ]);
+
+    expect(ids(editions)).toEqual([["a", "b", "c"]]);
+    expect(editions[0]!.kind).toBe("set");
+    expect(editions[0]!.representative.id).toBe("a");
+    expect(editions[0]!.setId).toBe("set");
+  });
+
+  it("orders parts with no number last, then by id", () => {
+    const editions = toEditions([
+      media("z", { recordingGroupId: "set" }),
+      media("b", { recordingGroupId: "set", partNumber: 2 }),
+      media("m", { recordingGroupId: "set" }),
+      media("a", { recordingGroupId: "set", partNumber: 1 }),
+    ]);
+
+    expect(ids(editions)).toEqual([["a", "b", "m", "z"]]);
+  });
+
+  it("presents a set with one visible part as a single edition", () => {
+    // the rest of the set is still processing, so only part 1 is visible; a
+    // one-part stack is noise, not a set
+    const editions = toEditions([
+      media("a", { recordingGroupId: "set", partNumber: 1 }),
+    ]);
+
+    expect(editions).toHaveLength(1);
+    expect(editions[0]!.kind).toBe("single");
+    expect(editions[0]!.setId).toBeNull();
+  });
+
+  it("keeps two sets of the same book apart", () => {
+    const editions = toEditions([
+      media("a1", {
+        recordingGroupId: "one",
+        partNumber: 1,
+        published: new Date("2019-01-01"),
+      }),
+      media("b1", {
+        recordingGroupId: "two",
+        partNumber: 1,
+        published: new Date("2023-01-01"),
+      }),
+      media("a2", { recordingGroupId: "one", partNumber: 2 }),
+      media("b2", { recordingGroupId: "two", partNumber: 2 }),
+    ]);
+
+    expect(ids(editions)).toEqual([
+      ["b1", "b2"],
+      ["a1", "a2"],
+    ]);
+  });
+
+  it("dates a set by its first part, not its newest", () => {
+    // part 3 is the most recent release, but the set is as old as it started
+    const editions = toEditions([
+      media("solo", { published: new Date("2021-01-01") }),
+      media("p1", {
+        recordingGroupId: "set",
+        partNumber: 1,
+        published: new Date("2020-01-01"),
+      }),
+      media("p3", {
+        recordingGroupId: "set",
+        partNumber: 3,
+        published: new Date("2022-01-01"),
+      }),
+    ]);
+
+    expect(ids(editions)).toEqual([["solo"], ["p1", "p3"]]);
+  });
+
+  it("orders editions with no publish date last", () => {
+    const editions = toEditions([
+      media("undated"),
+      media("old", { published: new Date("1999-01-01") }),
+    ]);
+
+    expect(ids(editions)).toEqual([["old"], ["undated"]]);
+  });
+
+  it("breaks a publish-date tie by id, descending", () => {
+    const sameDay = new Date("2024-06-01");
+    const editions = toEditions([
+      media("a", { published: sameDay }),
+      media("c", { published: sameDay }),
+      media("b", { published: sameDay }),
+    ]);
+
+    expect(ids(editions)).toEqual([["c"], ["b"], ["a"]]);
+  });
+});
+
+describe("stackedRepresentatives", () => {
+  it("takes one cover per edition, newest first", () => {
+    const editions = toEditions([
+      media("new", { published: new Date("2024-01-01") }),
+      media("old", { published: new Date("2004-01-01") }),
+    ]);
+
+    expect(stackedRepresentatives(editions).map((m) => m.id)).toEqual([
+      "new",
+      "old",
+    ]);
+  });
+
+  it("collapses a set to its first part", () => {
+    // the sole-edition exception is dead: a book whose only edition is a
+    // three-part set shows one cover, not three
+    const editions = toEditions([
+      media("p1", { recordingGroupId: "set", partNumber: 1 }),
+      media("p2", { recordingGroupId: "set", partNumber: 2 }),
+      media("p3", { recordingGroupId: "set", partNumber: 3 }),
+    ]);
+
+    expect(stackedRepresentatives(editions).map((m) => m.id)).toEqual(["p1"]);
+  });
+
+  it("caps at three covers", () => {
+    const editions = toEditions([
+      media("a", { published: new Date("2024-01-01") }),
+      media("b", { published: new Date("2023-01-01") }),
+      media("c", { published: new Date("2022-01-01") }),
+      media("d", { published: new Date("2021-01-01") }),
+    ]);
+
+    expect(stackedRepresentatives(editions).map((m) => m.id)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+});

--- a/src/utils/editions.ts
+++ b/src/utils/editions.ts
@@ -1,0 +1,137 @@
+/**
+ * Editions — the "audiobook or set" union.
+ *
+ * A port of the server's `Ambry.Media.Editions`, which is the authority on
+ * these rules. Keep the two in step: the whole point of the edition model is
+ * that a stack means the same thing on every surface, web and mobile alike.
+ *
+ * An edition is one recorded edition of a book: either a standalone audiobook
+ * or a set (several recordings covering the book across separate releases).
+ * The rules:
+ *
+ *   * parts order within a set: part number (nulls last), then id
+ *   * a set with only one visible part presents as a single edition — a
+ *     one-part "set" is noise, not a stack
+ *   * representative: the first part / the audiobook itself
+ *   * editions order: representative publish date, newest first (a set's date
+ *     IS its first part's date), nulls last, id tiebreak
+ *
+ * Rendering is a recursive collapse, and the invariant is that a thing's
+ * in-stack representative is the first image of its expanded rendering. So
+ * index 0 of any list handed to `MultiThumbnailImage` is the cover that faces
+ * front, and only the ordering differs by what is being stacked: newest
+ * edition first for a book, first part first for a set.
+ *
+ * Filtering by status is the caller's job, done in SQL — readers never see
+ * non-ready recordings, and a query that pages has to apply it before the
+ * limit anyway.
+ */
+
+/** The columns an edition is computed from. */
+export type EditionMedia = {
+  id: string;
+  recordingGroupId: string | null;
+  partNumber: number | null;
+  published: Date | null;
+};
+
+export type Edition<M extends EditionMedia> = {
+  kind: "single" | "set";
+  /** Parts in order for a set; the recording itself for a single. */
+  media: M[];
+  representative: M;
+  /** The set this edition is, when it is one. */
+  setId: string | null;
+};
+
+/**
+ * Partitions a book's recordings into editions, newest first.
+ *
+ * A book whose recordings are all filtered out upstream yields `[]` — such a
+ * book is hidden entirely rather than rendered as an empty tile.
+ */
+export function toEditions<M extends EditionMedia>(media: M[]): Edition<M>[] {
+  const sets = new Map<string, M[]>();
+  const editions: Edition<M>[] = [];
+
+  for (const item of media) {
+    if (item.recordingGroupId === null) {
+      editions.push(singleEdition(item));
+    } else {
+      const parts = sets.get(item.recordingGroupId);
+      if (parts) parts.push(item);
+      else sets.set(item.recordingGroupId, [item]);
+    }
+  }
+
+  for (const [setId, parts] of sets) {
+    parts.sort(byPartOrder);
+    // one visible part is not a set
+    editions.push(
+      parts.length === 1
+        ? singleEdition(parts[0]!)
+        : { kind: "set", media: parts, representative: parts[0]!, setId },
+    );
+  }
+
+  return editions.sort(byNewestFirst);
+}
+
+/**
+ * The covers a stack shows, front first, capped at three.
+ *
+ * Every cover comes from an edition's representative, which is what keeps a
+ * collapsed stack and the tile it collapses to agreeing on their first image.
+ */
+export function stackedRepresentatives<M extends EditionMedia>(
+  editions: Edition<M>[],
+): M[] {
+  return editions
+    .slice(0, STACK_LIMIT)
+    .map((edition) => edition.representative);
+}
+
+/** Stacks show at most three covers, everywhere. */
+export const STACK_LIMIT = 3;
+
+function singleEdition<M extends EditionMedia>(media: M): Edition<M> {
+  return { kind: "single", media: [media], representative: media, setId: null };
+}
+
+/**
+ * Part number ascending, nulls last, then id.
+ *
+ * Exported because the library listing picks its representative in SQL and
+ * then sorts that set's parts here; both halves have to agree on the order or
+ * the front of the stack stops being the recording the tile opens.
+ */
+export function byPartOrder<M extends Pick<EditionMedia, "id" | "partNumber">>(
+  a: M,
+  b: M,
+): number {
+  if (a.partNumber !== b.partNumber) {
+    if (a.partNumber === null) return 1;
+    if (b.partNumber === null) return -1;
+    return a.partNumber - b.partNumber;
+  }
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+/** Publish date descending, nulls last, then id descending. */
+function byNewestFirst<M extends EditionMedia>(
+  a: Edition<M>,
+  b: Edition<M>,
+): number {
+  const aPublished = a.representative.published;
+  const bPublished = b.representative.published;
+
+  if (aPublished?.getTime() !== bPublished?.getTime()) {
+    if (aPublished === null) return 1;
+    if (bPublished === null) return -1;
+    return bPublished.getTime() - aPublished.getTime();
+  }
+
+  const aId = a.representative.id;
+  const bId = b.representative.id;
+  return aId < bId ? 1 : aId > bId ? -1 : 0;
+}

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -166,14 +166,36 @@ type Media = {
   title?: string | null;
 };
 
+export function useNavigateToMediaCallback(media: Media, book: Book) {
+  return useCallback(() => {
+    router.navigate({
+      pathname: "/media/[id]",
+      params: {
+        id: media.id,
+        title: recordingTitle(media.title, book.title),
+      },
+    });
+  }, [media, book]);
+}
+
+/**
+ * Where a book tile goes.
+ *
+ * `media` is the tile's collapsed list — one entry per edition — so a book
+ * with a single edition skips the book screen and opens that edition
+ * directly, even when the edition is a set of several parts. The book screen
+ * only earns its place when there is actually a choice to make.
+ */
 export function useNavigateToBookCallback(book: Book, media: Media[]) {
   return useCallback(() => {
-    if (media[0] && media.length === 1) {
+    const onlyEdition = media.length === 1 ? media[0] : undefined;
+
+    if (onlyEdition) {
       router.navigate({
         pathname: "/media/[id]",
         params: {
-          id: media[0].id,
-          title: recordingTitle(media[0].title, book.title),
+          id: onlyEdition.id,
+          title: recordingTitle(onlyEdition.title, book.title),
         },
       });
     } else {

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -341,6 +341,10 @@ export async function createMedia(
     fullCast: false,
     abridged: false,
     publishedFormat: "full",
+    // Ready by default: readers only ever see ready recordings, so a fixture
+    // without a status should be one that shows up. Pass a status explicitly
+    // to test what happens to the ones that do not.
+    status: "ready",
     insertedAt: now,
     updatedAt: now,
     ...rest,


### PR DESCRIPTION
The web app renders an **Edition** — "audiobook or set" — and collapses recursively: a book tile shows one cover per edition, a set inside that stack shows only its first part, and a set fans out only where it *is* the tile. Those rules live in `ROADMAP.history.md` under "Tile system v2" and are implemented once, in `Ambry.Media.Editions`.

The mobile app had no edition concept. `Tile` took a raw media list and stacked it.

## What was wrong

| | mobile before | web |
|---|---|---|
| Library, book with a 3-part set | 3 tiles | 1 tile, stacked |
| Book tile, only edition is a 3-part set | 3 covers | 1 cover |
| Book tile, two 3-part sets | 3 covers mixed across both sets | 2 covers, one per set |
| Other Editions, on a part of a set | the rest of your own set listed as alternates | excluded |
| Other Editions, a rival set | N separate tiles | 1 stacked tile |
| Book with one edition | opens the book screen | opens the recording |
| Book tiles / Other Editions / set parts | no status filter | ready only |

Non-ready recordings sync down by design — a status flip has to arrive as an update, not a deletion — so the missing filter was a real leak, just an invisible one on a server whose queue is always empty.

## The change

`src/utils/editions.ts` ports `Ambry.Media.Editions`: grouping, representative choice, and both orderings. Its doc comment names the server module as the authority, because the cost of the two drifting is this entire changeset.

## The stack order, which was inverted twice

`MultiThumbnailImage` painted its **last** cover on top; the web app puts index 0 in front. It looked correct anyway: every query fed it `published DESC`, so part 1 of a set — published earliest — arrived last and landed on top. Two inversions cancelling.

They stop cancelling for a book with several editions, where mobile shows the **oldest** cover in front and web shows the newest. And they would have stopped cancelling everywhere the moment these tiles started getting edition-ordered lists.

So the component now puts index 0 in front, and callers order their own lists — newest edition first for a book, first part first for a set. One invariant, stated in both files: **the front cover is the thing the tile opens.**

## Judgment calls worth a second opinion

- **A set tile opens its first part**, matching web, rather than the set screen. The part's screen already carries the rest of the set and it can actually be played; the set screen stays reachable from "Rest of this set". Say the word if you'd rather it open the set screen.
- **Search collapses too.** It was returning one hit per part. Web's search shows book tiles, a different model, so this isn't a straight port — but one result per set beats five.
- **Ordering matches web exactly**, which means editions date by `media.published` alone. Mobile's queries used to fall back to the book's date via `COALESCE`. The fallback is arguably nicer; it just isn't what web does, and I'd rather the two agree than quietly differ. Easy to change in both.
- `partsLabel` still prefers the set's declared `partsTotal` where web counts visible parts, so a 3-part set with 2 ready says "3 parts" on mobile and "2 parts" on web. Left alone — pre-existing and not obviously wrong.

## Testing

- 12 new unit tests for `toEditions` / `stackedRepresentatives`, covering both orderings, the one-part-set collapse, the dead sole-edition exception, and the 3-cover cap.
- 6 new query tests for the library collapse: representative choice with a non-ready part 1, part-order stacking, pages that fill with entries rather than parts.
- 4 new tests for Other Editions, including the lone-sibling trap that ambry#1165 fixed on web — with one part left over, dropping only the current recording leaves a one-part set, which collapses to a single edition and presents itself as a rival edition.
- `createMedia` now defaults to `status: "ready"`, since readers only ever see ready recordings.
- 807 tests pass; `tsc` and `lint` clean.

## Not in this PR

Honouring the set's **name** needs `show_label`, which the server doesn't send yet — ambry#1247. That needs a schema column and a migration and can't ship until the server is deployed. This PR has neither dependency and can go out on its own.

I have not run this on a device yet.