### PR TITLE
Collapse the player when its menu starts a download

### DIFF
--- a/src/components/PlayerContextMenu.tsx
+++ b/src/components/PlayerContextMenu.tsx
@@ -88,10 +88,13 @@ export function PlayerContextMenu({
     await abandonPlaythrough(session, playthroughId);
   }, [session, playthroughId]);
 
+  // Collapses for the same reason the other two navigating items do: the
+  // expanded player covers the screen it is sending you to.
   const handleDownload = useCallback(() => {
+    onCollapse();
     startDownload(session, mediaId);
     router.navigate("/downloads");
-  }, [session, mediaId]);
+  }, [session, mediaId, onCollapse]);
 
   return (
     <PlayerContextMenuImpl


### PR DESCRIPTION
Closes #79.

**Download** in the player's context menu queues the download and navigates to the Downloads screen, but left the player expanded on top of it — so from the reader's side nothing happened.

`handleGoToBook` and the author/narrator items already call `onCollapse()` before navigating. `handleDownload` was the only navigating item that didn't. It does now.

## The one I left alone

`handleUnloadPlayer` also navigates without collapsing, but that one is correct: it opens the mark-finished prompt as a modal over the player, and answering it unloads the player anyway. Dismissing it puts you back where you were.

## Testing

`tsc`, `lint` and 785 tests pass, but none of them cover this — the menu renders through `@expo/ui/jetpack-compose` native views, and a test that mocked our own impl to observe the call order would be testing the implementation rather than the outcome. It wants an eyeball on a device: open the player, expand it, ⋮ → Download, and the player should drop to the mini bar with the Downloads screen behind it.

Branched off `main`, independent of #80 and #81 — merges in any order.