### PR TITLE
Keep playing a downloaded file when its recording gains tracks

### DIFF
--- a/src/services/__tests__/track-player-service.test.ts
+++ b/src/services/__tests__/track-player-service.test.ts
@@ -21,6 +21,7 @@ import { setupTestDatabase } from "@test/db-test-utils";
 import {
   createDownload,
   createMedia,
+  createMediaTrack,
   createPlaythrough,
   DEFAULT_TEST_SESSION,
 } from "@test/factories";
@@ -181,6 +182,114 @@ describe("track-player-service", () => {
       await trackPlayerService.loadPlaythroughIntoPlayer(session, playthrough);
 
       expect(useTrackPlayer.getState().streaming).toBe(false);
+    });
+
+    // The back-catalogue reclaim relinks a legacy recording to its original
+    // files and gives it tracks. Everyone already holding a download of it has
+    // a perfectly good copy of the same book on disk, keyed to nothing the new
+    // tracks mention.
+    describe("a downloaded recording that has since gained tracks", () => {
+      async function downloadedThenRelinked() {
+        const db = getDb();
+        const media = await createMedia(db, {
+          duration: "300.0",
+          hlsPath: "/audio/test/hls.m3u8",
+          mpdPath: "/audio/test/manifest.mpd",
+        });
+        // Downloaded while it was still legacy: one packaged file, no per-track
+        // files, because there were no tracks to key them to.
+        await createDownload(db, {
+          mediaId: media.id,
+          filePath: "legacy-download.mp4",
+        });
+        // Relinked since: two files it has never been told about.
+        await createMediaTrack(db, {
+          mediaId: media.id,
+          index: 0,
+          startOffset: 0,
+          duration: 100,
+          path: "/library/a.mp3",
+        });
+        await createMediaTrack(db, {
+          mediaId: media.id,
+          index: 1,
+          startOffset: 100,
+          duration: 200,
+          path: "/library/b.mp3",
+        });
+        const playthrough = await createPlaythrough(db, {
+          mediaId: media.id,
+          status: "in_progress",
+        });
+        return getPlaythroughWithMedia(session, playthrough.id);
+      }
+
+      it("keeps playing the downloaded file instead of streaming the tracks", async () => {
+        const playthrough = await downloadedThenRelinked();
+
+        await trackPlayerService.loadPlaythroughIntoPlayer(
+          session,
+          playthrough,
+        );
+
+        const queue = trackPlayerFake.getState().queue as { url: string }[];
+        expect(queue).toHaveLength(1);
+        expect(queue[0]!.url).toContain("legacy-download.mp4");
+        expect(useTrackPlayer.getState().streaming).toBe(false);
+      });
+
+      // The queue and the timeline describe the same thing and are wrong
+      // apart: a two-file timeline over a one-file queue would translate a
+      // position past 100s into a skip to a track the player does not have.
+      it("reports position against the whole file, not the track timeline", async () => {
+        const playthrough = await downloadedThenRelinked();
+
+        await trackPlayerService.loadPlaythroughIntoPlayer(
+          session,
+          playthrough,
+        );
+        await trackPlayerService.seekTo(150, SeekSource.SCRUBBER);
+
+        const { position } = trackPlayerFake.getState();
+        expect(position).toBe(150);
+      });
+    });
+
+    // The mirror image, and the reason the fallback is narrow: per-track local
+    // files are keyed by track id so that a re-scan invalidates them rather
+    // than mapping playback onto the wrong file. Guessing an order would be
+    // exactly that mistake, so this one streams.
+    it("streams a direct-play recording whose downloaded files no longer match its tracks", async () => {
+      const db = getDb();
+      const media = await createMedia(db, { duration: "300.0" });
+      await createMediaTrack(db, {
+        mediaId: media.id,
+        index: 0,
+        startOffset: 0,
+        duration: 300,
+        path: "/library/new.mp3",
+      });
+      // A direct-play download carries no `filePath`; its files name track ids
+      // that a re-scan has since replaced.
+      await createDownload(db, {
+        mediaId: media.id,
+        filePath: "",
+        files: [{ trackId: "a-track-that-no-longer-exists", path: "old.mp3" }],
+      });
+      const playthrough = await createPlaythrough(db, {
+        mediaId: media.id,
+        status: "in_progress",
+      });
+
+      await trackPlayerService.loadPlaythroughIntoPlayer(
+        session,
+        (await getPlaythroughWithMedia(session, playthrough.id))!,
+      );
+
+      const queue = trackPlayerFake.getState().queue as { url: string }[];
+      expect(queue).toHaveLength(1);
+      expect(queue[0]!.url).toContain("/library/new.mp3");
+      expect(queue[0]!.url).not.toContain("old.mp3");
     });
 
     it("never reports an empty player while swapping one book for another", async () => {

--- a/src/services/track-player-service.ts
+++ b/src/services/track-player-service.ts
@@ -43,6 +43,7 @@ import {
 } from "@/types/track-player";
 import { logBase } from "@/utils/logger";
 import { documentDirectoryFilePath } from "@/utils/paths";
+import { type TimelineTrack } from "@/utils/playback-timeline";
 import { subscribeToChange } from "@/utils/subscribe";
 import { recordingTitle } from "@/utils/titles";
 import { serverUrl } from "@/utils/urls";
@@ -341,8 +342,7 @@ export async function loadPlaythroughIntoPlayer(
   const position = getEffectivePosition(playthrough);
   const playbackRate = playthrough.playbackRate;
 
-  const tracks = buildAddTracks(session, playthrough);
-  const timeline = playthrough.media.mediaTracks;
+  const { tracks, timeline } = buildQueue(session, playthrough);
 
   const loaded = {
     id: playthrough.id,
@@ -421,10 +421,8 @@ export async function reloadCurrentPlaythrough(
   await TrackPlayer.reset();
 
   // Load new track configuration (switches URL between file/stream)
-  await TrackPlayer.add(
-    buildAddTracks(session, playthrough),
-    playthrough.media.mediaTracks,
-  );
+  const { tracks, timeline } = buildQueue(session, playthrough);
+  await TrackPlayer.add(tracks, timeline);
 
   // Restore state
   await TrackPlayer.seekTo(position);
@@ -734,18 +732,32 @@ function stopTrackingProgress() {
   progressCheckInterval = null;
 }
 
+/** A queue and the timeline that describes it. Never one without the other. */
+export type Queue = {
+  tracks: AddTrack[];
+  timeline: TimelineTrack[];
+};
+
 /**
- * Build the player's queue for a playthrough.
+ * Build the player's queue for a playthrough, with its timeline.
  *
  * A direct-play recording is its files in order; legacy media is the single
  * packaged stream it has always been. Every entry carries the same title,
  * artist and artwork, so the lock screen and notification describe the book
  * rather than announcing which file is playing.
+ *
+ * **The timeline comes back with the queue because the two describe the same
+ * thing and are wrong apart.** `track-player-wrapper` translates book seconds
+ * against the timeline and skips against the queue, so a timeline of forty
+ * files over a queue of one sends `skip(37, …)` into a player holding a single
+ * track. Callers used to pass `media.mediaTracks` alongside separately, which
+ * was true only for as long as nothing could make the queue disagree with it —
+ * and the fallback below is exactly that.
  */
-function buildAddTracks(
+function buildQueue(
   session: Session,
   playthrough: PlaythroughWithMedia,
-): AddTrack[] {
+): Queue {
   const shared = {
     pitchAlgorithm: PitchAlgorithm.Voice,
     title: recordingTitle(
@@ -761,24 +773,68 @@ function buildAddTracks(
   };
 
   const tracks = playthrough.media.mediaTracks;
+  const legacyFile = strandedLegacyFile(playthrough);
 
-  if (tracks.length > 0) {
-    return tracks.map((track) => ({
-      ...shared,
-      ...directPlaySource(session, playthrough, track),
-      duration: track.duration,
-    }));
+  if (tracks.length > 0 && !legacyFile) {
+    return {
+      tracks: tracks.map((track) => ({
+        ...shared,
+        ...directPlaySource(session, playthrough, track),
+        duration: track.duration,
+      })),
+      timeline: tracks,
+    };
   }
 
-  return [
-    {
-      ...shared,
-      ...legacySource(session, playthrough),
-      duration: playthrough.media.duration
-        ? parseFloat(playthrough.media.duration)
-        : undefined,
-    },
-  ];
+  return {
+    tracks: [
+      {
+        ...shared,
+        ...(legacyFile
+          ? localSource(legacyFile, playthrough)
+          : legacySource(session, playthrough)),
+        duration: playthrough.media.duration
+          ? parseFloat(playthrough.media.duration)
+          : undefined,
+      },
+    ],
+    // One file holding the whole book needs no translation, which is what an
+    // empty timeline means to the wrapper.
+    timeline: [],
+  };
+}
+
+/**
+ * The downloaded packaged file of a recording that has since gained tracks,
+ * if that is the situation we are in.
+ *
+ * The back-catalogue reclaim relinks a legacy recording to its original files
+ * and gives it tracks. Anyone holding a download of it has a perfectly good
+ * copy of the same book on disk, keyed to nothing the new tracks mention — so
+ * without this the queue would be built from the tracks, no local file would
+ * match any of them, and the reader would silently start streaming a book they
+ * had already downloaded, over whatever connection they happen to be on.
+ *
+ * Playing their copy is unambiguous: it is one file and it is the whole book.
+ *
+ * The condition is deliberately narrow. `filePath` is only ever set for a
+ * legacy download (`download-service` writes `""` for a direct-play one), so a
+ * *per-track* download whose tracks were replaced by a re-scan does not land
+ * here — its local files are keyed by track id precisely so that a re-scan
+ * invalidates them rather than mapping playback onto the wrong file, and
+ * guessing an order for them would be exactly that mistake. Those re-download.
+ */
+function strandedLegacyFile(playthrough: PlaythroughWithMedia) {
+  const download = playthrough.media.download;
+  if (download?.status !== "ready") return null;
+  if (playthrough.media.mediaTracks.length === 0) return null;
+  if (!download.filePath) return null;
+
+  const hasLocalTrack = playthrough.media.mediaTracks.some((track) =>
+    download.files?.some((file) => file.trackId === track.id),
+  );
+
+  return hasLocalTrack ? null : download.filePath;
 }
 
 type MediaTrack = PlaythroughWithMedia["media"]["mediaTracks"][number];
@@ -825,6 +881,24 @@ function directPlaySource(
 }
 
 /**
+ * A file on this device, with the artwork that was downloaded beside it.
+ *
+ * No `type`: the packaged mp4 is a plain file to the player, and letting it
+ * sniff the container is what makes this work for both the pre-tracks case and
+ * a recording that has since gained them.
+ */
+function localSource(path: string, playthrough: PlaythroughWithMedia) {
+  const download = playthrough.media.download;
+
+  return {
+    url: documentDirectoryFilePath(path),
+    artwork: download?.thumbnails
+      ? documentDirectoryFilePath(download.thumbnails.extraLarge)
+      : undefined,
+  };
+}
+
+/**
  * Where legacy packaged media comes from: the downloaded mp4 if there is one,
  * otherwise the streaming manifest — HLS on iOS, DASH elsewhere.
  */
@@ -832,12 +906,7 @@ function legacySource(session: Session, playthrough: PlaythroughWithMedia) {
   const download = playthrough.media.download;
 
   if (download?.status === "ready" && download.filePath) {
-    return {
-      url: documentDirectoryFilePath(download.filePath),
-      artwork: download.thumbnails
-        ? documentDirectoryFilePath(download.thumbnails.extraLarge)
-        : undefined,
-    };
+    return localSource(download.filePath, playthrough);
   }
 
   const path =


### PR DESCRIPTION
A download taken while a recording was still legacy stops being used the
moment that recording gains tracks, and the app keeps calling it downloaded.

`buildAddTracks` branched on `mediaTracks.length > 0` before it looked at the
download, and matched local copies by `trackId`. A legacy download has
`files = null`, so every track misses and streams — on wifi that is a
download that quietly does nothing, and offline it is a book the reader
deliberately downloaded that will not start.

The back-catalogue reclaim is about to make that real: relinking a legacy
recording keeps its media id and gives it tracks, so every existing download
of it is stranded.

## What this does

When a recording has tracks, none has a local copy, and the download carries
a legacy `filePath`, play that file. One file, whole book, unambiguous.

Narrow on purpose: `filePath` is only ever set for a legacy download
(`download-service` writes `""` for direct-play), so a per-track download
whose tracks were replaced by a re-scan does **not** land here. Those files
are keyed by track id specifically so a re-scan invalidates them instead of
mapping playback onto the wrong file; guessing their order would be that
mistake. Those re-download.

## The part that was nearly a bug

Both call sites passed the timeline separately from the queue. That held only
while nothing could make the two disagree — and this fallback is exactly
that. A one-file queue under a two-file timeline sends `skip(1, 50)` into a
player holding one track. `buildQueue` now returns both together.

## Risk

Inert on today's library: no recording with a legacy download has tracks, so
the new branch is unreachable until something relinks. Every pre-existing
case gets byte-identical inputs to before.

Both new tests were verified to fail with the fallback stubbed out, rather
than assumed to cover it.

https://claude.ai/code/session_01PXFb3yiAWDmi9aZPdBJDoQ
