### PR TITLE
Regenerate types without the browse-era GraphQL surface

### DIFF
--- a/src/graphql/client/graphql.ts
+++ b/src/graphql/client/graphql.ts
@@ -36,23 +36,11 @@ export type Scalars = {
 
 export type Author = Node & {
   __typename?: 'Author';
-  authoredBooks?: Maybe<BookConnection>;
   /** The ID of an object */
   id: Scalars['ID']['output'];
   insertedAt: Scalars['DateTime']['output'];
   name: Scalars['String']['output'];
-  people: Array<Person>;
-  /** @deprecated use `people` instead; an author can be linked to multiple people */
-  person: Person;
   updatedAt: Scalars['DateTime']['output'];
-};
-
-
-export type AuthorAuthoredBooksArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type AuthorPerson = Node & {
@@ -67,16 +55,12 @@ export type AuthorPerson = Node & {
 
 export type Book = Node & {
   __typename?: 'Book';
-  authors: Array<Author>;
   /** The ID of an object */
   id: Scalars['ID']['output'];
   insertedAt: Scalars['DateTime']['output'];
-  media: Array<Media>;
   published: Scalars['Date']['output'];
   publishedFormat: DateFormat;
-  seriesBooks: Array<SeriesBook>;
   title: Scalars['String']['output'];
-  universes: Array<Universe>;
   updatedAt: Scalars['DateTime']['output'];
 };
 
@@ -89,18 +73,6 @@ export type BookAuthor = Node & {
   insertedAt: Scalars['DateTime']['output'];
   position: Scalars['Int']['output'];
   updatedAt: Scalars['DateTime']['output'];
-};
-
-export type BookConnection = {
-  __typename?: 'BookConnection';
-  edges?: Maybe<Array<Maybe<BookEdge>>>;
-  pageInfo: PageInfo;
-};
-
-export type BookEdge = {
-  __typename?: 'BookEdge';
-  cursor?: Maybe<Scalars['String']['output']>;
-  node?: Maybe<Book>;
 };
 
 export type BookUniverse = Node & {
@@ -204,7 +176,6 @@ export type Media = Node & {
   insertedAt: Scalars['DateTime']['output'];
   mp4Path?: Maybe<Scalars['String']['output']>;
   mpdPath?: Maybe<Scalars['String']['output']>;
-  narrators: Array<Narrator>;
   notes?: Maybe<Scalars['String']['output']>;
   /** For multi-part recordings: this recording's position in its part set; the set's total lives on the recording group */
   partNumber?: Maybe<Scalars['Int']['output']>;
@@ -217,21 +188,7 @@ export type Media = Node & {
   thumbnails?: Maybe<Thumbnails>;
   /** Display-title override for this recording (translated/regional/retail title); null means the book's title applies */
   title?: Maybe<Scalars['String']['output']>;
-  /** Direct-play audio files, in playback order; empty for media that only has the legacy packaged artifacts below */
-  tracks: Array<MediaTrack>;
   updatedAt: Scalars['DateTime']['output'];
-};
-
-export type MediaConnection = {
-  __typename?: 'MediaConnection';
-  edges?: Maybe<Array<Maybe<MediaEdge>>>;
-  pageInfo: PageInfo;
-};
-
-export type MediaEdge = {
-  __typename?: 'MediaEdge';
-  cursor?: Maybe<Scalars['String']['output']>;
-  node?: Maybe<Media>;
 };
 
 export type MediaNarrator = Node & {
@@ -284,17 +241,8 @@ export type Narrator = Node & {
   id: Scalars['ID']['output'];
   insertedAt: Scalars['DateTime']['output'];
   name: Scalars['String']['output'];
-  narratedMedia?: Maybe<MediaConnection>;
   person: Person;
   updatedAt: Scalars['DateTime']['output'];
-};
-
-
-export type NarratorNarratedMediaArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type Node = {
@@ -302,21 +250,8 @@ export type Node = {
   id: Scalars['ID']['output'];
 };
 
-export type PageInfo = {
-  __typename?: 'PageInfo';
-  /** When paginating forwards, the cursor to continue. */
-  endCursor?: Maybe<Scalars['String']['output']>;
-  /** When paginating forwards, are there more items? */
-  hasNextPage: Scalars['Boolean']['output'];
-  /** When paginating backwards, are there more items? */
-  hasPreviousPage: Scalars['Boolean']['output'];
-  /** When paginating backwards, the cursor to continue. */
-  startCursor?: Maybe<Scalars['String']['output']>;
-};
-
 export type Person = Node & {
   __typename?: 'Person';
-  authors: Array<Author>;
   description?: Maybe<Scalars['String']['output']>;
   /** The ID of an object */
   id: Scalars['ID']['output'];
@@ -324,7 +259,6 @@ export type Person = Node & {
   imagePath?: Maybe<Scalars['String']['output']>;
   insertedAt: Scalars['DateTime']['output'];
   name: Scalars['String']['output'];
-  narrators: Array<Narrator>;
   thumbnails?: Maybe<Thumbnails>;
   updatedAt: Scalars['DateTime']['output'];
 };
@@ -376,7 +310,6 @@ export type RecordingGroup = Node & {
   /** The ID of an object */
   id: Scalars['ID']['output'];
   insertedAt: Scalars['DateTime']['output'];
-  media: Array<Media>;
   /** This set's name, shown to readers only when `show_label` says so */
   name: Scalars['String']['output'];
   /** Wording for one release in this set; null means "part" */
@@ -421,7 +354,6 @@ export type RootQueryType = {
   mediaNarratorsChangedSince: Array<MediaNarrator>;
   mediaTracksChangedSince: Array<MediaTrack>;
   narratorsChangedSince: Array<Narrator>;
-  node?: Maybe<Node>;
   peopleChangedSince: Array<Person>;
   recordingGroupsChangedSince: Array<RecordingGroup>;
   seriesBooksChangedSince: Array<SeriesBook>;
@@ -481,11 +413,6 @@ export type RootQueryTypeNarratorsChangedSinceArgs = {
 };
 
 
-export type RootQueryTypeNodeArgs = {
-  id: Scalars['ID']['input'];
-};
-
-
 export type RootQueryTypePeopleChangedSinceArgs = {
   since?: InputMaybe<Scalars['DateTime']['input']>;
 };
@@ -524,16 +451,7 @@ export type Series = Node & {
   id: Scalars['ID']['output'];
   insertedAt: Scalars['DateTime']['output'];
   name: Scalars['String']['output'];
-  seriesBooks?: Maybe<SeriesBookConnection>;
   updatedAt: Scalars['DateTime']['output'];
-};
-
-
-export type SeriesSeriesBooksArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type SeriesBook = Node & {
@@ -546,18 +464,6 @@ export type SeriesBook = Node & {
   position: Scalars['Int']['output'];
   series: Series;
   updatedAt: Scalars['DateTime']['output'];
-};
-
-export type SeriesBookConnection = {
-  __typename?: 'SeriesBookConnection';
-  edges?: Maybe<Array<Maybe<SeriesBookEdge>>>;
-  pageInfo: PageInfo;
-};
-
-export type SeriesBookEdge = {
-  __typename?: 'SeriesBookEdge';
-  cursor?: Maybe<Scalars['String']['output']>;
-  node?: Maybe<SeriesBook>;
 };
 
 export type SupplementalFile = {
@@ -593,7 +499,6 @@ export type Thumbnails = {
 
 export type Universe = Node & {
   __typename?: 'Universe';
-  books: Array<Book>;
   /** The ID of an object */
   id: Scalars['ID']['output'];
   insertedAt: Scalars['DateTime']['output'];

--- a/src/graphql/client/graphql.ts
+++ b/src/graphql/client/graphql.ts
@@ -65,7 +65,7 @@ export type AuthorPerson = Node & {
   updatedAt: Scalars['DateTime']['output'];
 };
 
-export type Book = Node & SearchResult & {
+export type Book = Node & {
   __typename?: 'Book';
   authors: Array<Author>;
   /** The ID of an object */
@@ -314,7 +314,7 @@ export type PageInfo = {
   startCursor?: Maybe<Scalars['String']['output']>;
 };
 
-export type Person = Node & SearchResult & {
+export type Person = Node & {
   __typename?: 'Person';
   authors: Array<Author>;
   description?: Maybe<Scalars['String']['output']>;
@@ -414,7 +414,6 @@ export type RootQueryType = {
   authorsChangedSince: Array<Author>;
   bookAuthorsChangedSince: Array<BookAuthor>;
   bookUniversesChangedSince: Array<BookUniverse>;
-  books?: Maybe<BookConnection>;
   booksChangedSince: Array<Book>;
   deletionsSince: Array<Deletion>;
   me?: Maybe<User>;
@@ -425,7 +424,6 @@ export type RootQueryType = {
   node?: Maybe<Node>;
   peopleChangedSince: Array<Person>;
   recordingGroupsChangedSince: Array<RecordingGroup>;
-  search?: Maybe<SearchResultConnection>;
   seriesBooksChangedSince: Array<SeriesBook>;
   seriesChangedSince: Array<Series>;
   serverTime: Scalars['DateTime']['output'];
@@ -450,14 +448,6 @@ export type RootQueryTypeBookAuthorsChangedSinceArgs = {
 
 export type RootQueryTypeBookUniversesChangedSinceArgs = {
   since?: InputMaybe<Scalars['DateTime']['input']>;
-};
-
-
-export type RootQueryTypeBooksArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -506,15 +496,6 @@ export type RootQueryTypeRecordingGroupsChangedSinceArgs = {
 };
 
 
-export type RootQueryTypeSearchArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  query: Scalars['String']['input'];
-};
-
-
 export type RootQueryTypeSeriesBooksChangedSinceArgs = {
   since?: InputMaybe<Scalars['DateTime']['input']>;
 };
@@ -529,22 +510,6 @@ export type RootQueryTypeUniversesChangedSinceArgs = {
   since?: InputMaybe<Scalars['DateTime']['input']>;
 };
 
-export type SearchResult = {
-  id: Scalars['ID']['output'];
-};
-
-export type SearchResultConnection = {
-  __typename?: 'SearchResultConnection';
-  edges?: Maybe<Array<Maybe<SearchResultEdge>>>;
-  pageInfo: PageInfo;
-};
-
-export type SearchResultEdge = {
-  __typename?: 'SearchResultEdge';
-  cursor?: Maybe<Scalars['String']['output']>;
-  node?: Maybe<SearchResult>;
-};
-
 /** How accurately a player can seek within a track */
 export enum SeekAccuracy {
   /** The file carries no seek index (e.g. VBR mp3 with no Xing header); positions may drift */
@@ -553,7 +518,7 @@ export enum SeekAccuracy {
   Exact = 'EXACT'
 }
 
-export type Series = Node & SearchResult & {
+export type Series = Node & {
   __typename?: 'Series';
   /** The ID of an object */
   id: Scalars['ID']['output'];

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -23,7 +23,7 @@ type AuthorPerson implements Node {
   updatedAt: DateTime!
 }
 
-type Book implements Node & SearchResult {
+type Book implements Node {
   authors: [Author!]!
   """The ID of an object"""
   id: ID!
@@ -286,7 +286,7 @@ type PageInfo {
   startCursor: String
 }
 
-type Person implements Node & SearchResult {
+type Person implements Node {
   authors: [Author!]!
   description: String
   """The ID of an object"""
@@ -378,7 +378,6 @@ type RootQueryType {
   authorsChangedSince(since: DateTime): [Author!]!
   bookAuthorsChangedSince(since: DateTime): [BookAuthor!]!
   bookUniversesChangedSince(since: DateTime): [BookUniverse!]!
-  books(after: String, before: String, first: Int, last: Int): BookConnection
   booksChangedSince(since: DateTime): [Book!]!
   deletionsSince(since: DateTime): [Deletion!]!
   me: User
@@ -392,32 +391,10 @@ type RootQueryType {
   ): Node
   peopleChangedSince(since: DateTime): [Person!]!
   recordingGroupsChangedSince(since: DateTime): [RecordingGroup!]!
-  search(
-    after: String
-    before: String
-    first: Int
-    last: Int
-    """Must be at least 3 characters"""
-    query: String!
-  ): SearchResultConnection
   seriesBooksChangedSince(since: DateTime): [SeriesBook!]!
   seriesChangedSince(since: DateTime): [Series!]!
   serverTime: DateTime!
   universesChangedSince(since: DateTime): [Universe!]!
-}
-
-interface SearchResult {
-  id: ID!
-}
-
-type SearchResultConnection {
-  edges: [SearchResultEdge]
-  pageInfo: PageInfo!
-}
-
-type SearchResultEdge {
-  cursor: String
-  node: SearchResult
 }
 
 """How accurately a player can seek within a track"""
@@ -430,7 +407,7 @@ enum SeekAccuracy {
   EXACT
 }
 
-type Series implements Node & SearchResult {
+type Series implements Node {
   """The ID of an object"""
   id: ID!
   insertedAt: DateTime!

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -4,13 +4,10 @@ schema {
 }
 
 type Author implements Node {
-  authoredBooks(after: String, before: String, first: Int, last: Int): BookConnection
   """The ID of an object"""
   id: ID!
   insertedAt: DateTime!
   name: String!
-  people: [Person!]!
-  person: Person! @deprecated(reason: "use `people` instead; an author can be linked to multiple people")
   updatedAt: DateTime!
 }
 
@@ -24,16 +21,12 @@ type AuthorPerson implements Node {
 }
 
 type Book implements Node {
-  authors: [Author!]!
   """The ID of an object"""
   id: ID!
   insertedAt: DateTime!
-  media: [Media!]!
   published: Date!
   publishedFormat: DateFormat!
-  seriesBooks: [SeriesBook!]!
   title: String!
-  universes: [Universe!]!
   updatedAt: DateTime!
 }
 
@@ -45,16 +38,6 @@ type BookAuthor implements Node {
   insertedAt: DateTime!
   position: Int!
   updatedAt: DateTime!
-}
-
-type BookConnection {
-  edges: [BookEdge]
-  pageInfo: PageInfo!
-}
-
-type BookEdge {
-  cursor: String
-  node: Book
 }
 
 type BookUniverse implements Node {
@@ -172,7 +155,6 @@ type Media implements Node {
   insertedAt: DateTime!
   mp4Path: String
   mpdPath: String
-  narrators: [Narrator!]!
   notes: String
   """
   For multi-part recordings: this recording's position in its part set; the set's total lives on the recording group
@@ -189,21 +171,7 @@ type Media implements Node {
   Display-title override for this recording (translated/regional/retail title); null means the book's title applies
   """
   title: String
-  """
-  Direct-play audio files, in playback order; empty for media that only has the legacy packaged artifacts below
-  """
-  tracks: [MediaTrack!]!
   updatedAt: DateTime!
-}
-
-type MediaConnection {
-  edges: [MediaEdge]
-  pageInfo: PageInfo!
-}
-
-type MediaEdge {
-  cursor: String
-  node: Media
 }
 
 type MediaNarrator implements Node {
@@ -265,7 +233,6 @@ type Narrator implements Node {
   id: ID!
   insertedAt: DateTime!
   name: String!
-  narratedMedia(after: String, before: String, first: Int, last: Int): MediaConnection
   person: Person!
   updatedAt: DateTime!
 }
@@ -275,26 +242,13 @@ interface Node {
   id: ID!
 }
 
-type PageInfo {
-  """When paginating forwards, the cursor to continue."""
-  endCursor: String
-  """When paginating forwards, are there more items?"""
-  hasNextPage: Boolean!
-  """When paginating backwards, are there more items?"""
-  hasPreviousPage: Boolean!
-  """When paginating backwards, the cursor to continue."""
-  startCursor: String
-}
-
 type Person implements Node {
-  authors: [Author!]!
   description: String
   """The ID of an object"""
   id: ID!
   imagePath: String @deprecated(reason: "use `thumbnails` instead")
   insertedAt: DateTime!
   name: String!
-  narrators: [Narrator!]!
   thumbnails: Thumbnails
   updatedAt: DateTime!
 }
@@ -344,7 +298,6 @@ type RecordingGroup implements Node {
   """The ID of an object"""
   id: ID!
   insertedAt: DateTime!
-  media: [Media!]!
   """This set's name, shown to readers only when `show_label` says so"""
   name: String!
   """
@@ -385,10 +338,6 @@ type RootQueryType {
   mediaNarratorsChangedSince(since: DateTime): [MediaNarrator!]!
   mediaTracksChangedSince(since: DateTime): [MediaTrack!]!
   narratorsChangedSince(since: DateTime): [Narrator!]!
-  node(
-    """The ID of an object."""
-    id: ID!
-  ): Node
   peopleChangedSince(since: DateTime): [Person!]!
   recordingGroupsChangedSince(since: DateTime): [RecordingGroup!]!
   seriesBooksChangedSince(since: DateTime): [SeriesBook!]!
@@ -412,7 +361,6 @@ type Series implements Node {
   id: ID!
   insertedAt: DateTime!
   name: String!
-  seriesBooks(after: String, before: String, first: Int, last: Int): SeriesBookConnection
   updatedAt: DateTime!
 }
 
@@ -425,16 +373,6 @@ type SeriesBook implements Node {
   position: Int!
   series: Series!
   updatedAt: DateTime!
-}
-
-type SeriesBookConnection {
-  edges: [SeriesBookEdge]
-  pageInfo: PageInfo!
-}
-
-type SeriesBookEdge {
-  cursor: String
-  node: SeriesBook
 }
 
 type SupplementalFile {
@@ -466,7 +404,6 @@ type Thumbnails {
 }
 
 type Universe implements Node {
-  books: [Book!]!
   """The ID of an object"""
   id: ID!
   insertedAt: DateTime!


### PR DESCRIPTION
The mobile half of the server change that deletes the browse-era GraphQL
surface.

Generated output only — no hand-written source changed. `npm run codegen`
against the server on that branch, in two steps so the diff is readable:

1. **The browse-era search surface.** The server dropped the `search` and
   `books` root queries and the `SearchResult` interface. Nothing in this app
   ever queried them — search here reads local SQLite through
   `getSearchedMedia`, not the server.
2. **The Relay node surface.** The server retired `node(id:)` and the has-many
   fields only it could reach. `LibraryChangesSince` asks for flat scalars and
   `{ id }` on belongs-to associations, so none of them were reachable from
   here either.

Sync is untouched: all fourteen `*ChangedSince` fields and the `Node` interface
are still in the schema, which is what hands out the global ids sync is keyed
on.

## This does not need the server released first

The diff changes type declarations only — **no operation document moved**, so
the app sends byte-identical queries and nothing on the wire changes. The three
added lines are just `Book`, `Person` and `Series` being re-declared as
`Node & { … }` after losing their has-many fields.

The direction is the safe one, too: dropping local types for fields the server
still serves leaves the server a superset of what we describe. The dangerous
direction is the opposite — keeping types for fields the server has removed.

## Testing

`npx tsc --noEmit` and `npm run lint` both clean. Since this is purely the
removal of types nothing referenced, a clean typecheck is the actual proof
there were no callers.
