### PR TITLE
The headset's play/pause key had nowhere to go

### DIFF
--- a/src/services/__tests__/playback-service.test.ts
+++ b/src/services/__tests__/playback-service.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for playback-service.ts
+ *
+ * Uses Detroit-style testing: only the native module is mocked (via
+ * jest-setup.ts). The real store, database and service logic runs.
+ *
+ * These cover the remote-control handlers, which are the app's only route from
+ * a headset or notification button to the player: RNTP's media session does
+ * not touch the underlying player itself, it emits an event and waits for us
+ * to issue the command.
+ */
+
+import { getPlaythroughWithMedia } from "@/db/playthroughs";
+import { PlaybackService } from "@/services/playback-service";
+import * as Player from "@/services/track-player-service";
+import {
+  PlayPauseSource,
+  PlayPauseType,
+  resetForTesting as resetTrackPlayerStore,
+  useTrackPlayer,
+} from "@/stores/track-player";
+import { Event } from "@/types/track-player";
+import { setupTestDatabase } from "@test/db-test-utils";
+import {
+  createMedia,
+  createPlaythrough,
+  DEFAULT_TEST_SESSION,
+} from "@test/factories";
+import {
+  mockTrackPlayerAddEventListener,
+  mockTrackPlayerPause,
+  mockTrackPlayerPlay,
+  resetTrackPlayerFake,
+} from "@test/jest-setup";
+
+// Set up fresh test DB
+const { getDb } = setupTestDatabase();
+
+const session = DEFAULT_TEST_SESSION;
+
+/**
+ * Register the service and return the handler it attached for an event, so a
+ * test can fire that event the way TrackPlayer would.
+ */
+async function handlerFor(event: Event) {
+  await PlaybackService();
+
+  const registration = mockTrackPlayerAddEventListener.mock.calls.find(
+    ([registered]) => registered === event,
+  );
+
+  if (!registration) {
+    throw new Error(`PlaybackService registered no handler for ${event}`);
+  }
+
+  // The mock types handlers as taking a payload and returning void. These take
+  // no payload and are async, and the tests need to await what they do.
+  return registration[1] as unknown as () => Promise<void>;
+}
+
+/**
+ * Create a playthrough and load it, so the player is in the state it would be
+ * in with a book open.
+ */
+async function loadPlaythrough(position: number) {
+  const db = getDb();
+
+  const media = await createMedia(db, {
+    duration: "300.0",
+    chapters: [{ id: "ch-1", title: "Chapter 1", startTime: 0, endTime: null }],
+    hlsPath: "/audio/test/hls.m3u8",
+    mpdPath: "/audio/test/manifest.mpd",
+  });
+
+  const playthrough = await createPlaythrough(db, {
+    mediaId: media.id,
+    status: "in_progress",
+    position,
+  });
+
+  const withMedia = await getPlaythroughWithMedia(session, playthrough.id);
+  await Player.loadPlaythroughIntoPlayer(session, withMedia);
+
+  return withMedia;
+}
+
+function setPlaying(playing: boolean) {
+  useTrackPlayer.setState({
+    isPlaying: { playing, bufferingDuringPlay: false },
+  });
+}
+
+describe("playback-service", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetTrackPlayerFake();
+    resetTrackPlayerStore();
+  });
+
+  describe("RemotePlayPause", () => {
+    // A headset's play/pause key arrives as this event and nothing else: RNTP
+    // maps KEYCODE_MEDIA_PLAY_PAUSE to it and reports the key handled, so
+    // media3 never resolves the toggle into a play or a pause of its own.
+    it("is handled at all", async () => {
+      await expect(handlerFor(Event.RemotePlayPause)).resolves.toBeDefined();
+    });
+
+    it("pauses when playing", async () => {
+      const handler = await handlerFor(Event.RemotePlayPause);
+      const playthrough = await loadPlaythrough(50);
+      setPlaying(true);
+
+      await handler();
+
+      expect(mockTrackPlayerPause).toHaveBeenCalled();
+      expect(mockTrackPlayerPlay).not.toHaveBeenCalled();
+
+      const { lastPlayPause } = useTrackPlayer.getState();
+      expect(lastPlayPause?.type).toBe(PlayPauseType.PAUSE);
+      expect(lastPlayPause?.source).toBe(PlayPauseSource.REMOTE);
+      expect(lastPlayPause?.playthroughId).toBe(playthrough.id);
+    });
+
+    it("plays when paused", async () => {
+      const handler = await handlerFor(Event.RemotePlayPause);
+      await loadPlaythrough(50);
+      setPlaying(false);
+
+      await handler();
+
+      expect(mockTrackPlayerPlay).toHaveBeenCalled();
+      expect(mockTrackPlayerPause).not.toHaveBeenCalled();
+
+      const { lastPlayPause } = useTrackPlayer.getState();
+      expect(lastPlayPause?.type).toBe(PlayPauseType.PLAY);
+      expect(lastPlayPause?.source).toBe(PlayPauseSource.REMOTE);
+    });
+
+    it("rewinds on pause, like every other pause", async () => {
+      const handler = await handlerFor(Event.RemotePlayPause);
+      await loadPlaythrough(100);
+      setPlaying(true);
+
+      await handler();
+
+      expect(useTrackPlayer.getState().progress.position).toBeLessThan(100);
+    });
+  });
+
+  describe("RemotePlay and RemotePause", () => {
+    // The notification's buttons take the other route, through the media
+    // session, and arrive as these.
+    it("plays on RemotePlay", async () => {
+      const handler = await handlerFor(Event.RemotePlay);
+      await loadPlaythrough(50);
+
+      await handler();
+
+      expect(mockTrackPlayerPlay).toHaveBeenCalled();
+      expect(useTrackPlayer.getState().lastPlayPause?.source).toBe(
+        PlayPauseSource.REMOTE,
+      );
+    });
+
+    it("pauses on RemotePause", async () => {
+      const handler = await handlerFor(Event.RemotePause);
+      await loadPlaythrough(50);
+
+      await handler();
+
+      expect(mockTrackPlayerPause).toHaveBeenCalled();
+      expect(useTrackPlayer.getState().lastPlayPause?.source).toBe(
+        PlayPauseSource.REMOTE,
+      );
+    });
+  });
+});

--- a/src/services/__tests__/playback-service.test.ts
+++ b/src/services/__tests__/playback-service.test.ts
@@ -13,10 +13,10 @@
 import { getPlaythroughWithMedia } from "@/db/playthroughs";
 import { PlaybackService } from "@/services/playback-service";
 import * as Player from "@/services/track-player-service";
+import { resetForTesting as resetTrackPlayerService } from "@/services/track-player-service";
 import {
   PlayPauseSource,
   PlayPauseType,
-  resetForTesting as resetTrackPlayerStore,
   useTrackPlayer,
 } from "@/stores/track-player";
 import { Event } from "@/types/track-player";
@@ -28,9 +28,8 @@ import {
 } from "@test/factories";
 import {
   mockTrackPlayerAddEventListener,
-  mockTrackPlayerPause,
-  mockTrackPlayerPlay,
   resetTrackPlayerFake,
+  trackPlayerFake,
 } from "@test/jest-setup";
 
 // Set up fresh test DB
@@ -39,8 +38,17 @@ const { getDb } = setupTestDatabase();
 const session = DEFAULT_TEST_SESSION;
 
 /**
+ * The native mock emits its events on a later tick, as the real module does.
+ */
+function flushNativeEvents() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+/**
  * Register the service and return the handler it attached for an event, so a
- * test can fire that event the way TrackPlayer would.
+ * test can fire it the way TrackPlayer would. There is no public way to emit
+ * an arbitrary event through the fake, and these handlers are the contract
+ * this file is about.
  */
 async function handlerFor(event: Event) {
   await PlaybackService();
@@ -59,8 +67,8 @@ async function handlerFor(event: Event) {
 }
 
 /**
- * Create a playthrough and load it, so the player is in the state it would be
- * in with a book open.
+ * Create a playthrough and load it through the real service, leaving the
+ * player in the state it would be in with a book open and paused.
  */
 async function loadPlaythrough(position: number) {
   const db = getDb();
@@ -84,36 +92,40 @@ async function loadPlaythrough(position: number) {
   return withMedia;
 }
 
-function setPlaying(playing: boolean) {
-  useTrackPlayer.setState({
-    isPlaying: { playing, bufferingDuringPlay: false },
-  });
-}
-
 describe("playback-service", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
     resetTrackPlayerFake();
-    resetTrackPlayerStore();
+    resetTrackPlayerService();
+
+    // Registers the listeners that keep isPlaying in step with the player, so
+    // the toggle below reads the state the real app would read.
+    await Player.initialize();
+  });
+
+  afterEach(() => {
+    resetTrackPlayerService();
   });
 
   describe("RemotePlayPause", () => {
     // A headset's play/pause key arrives as this event and nothing else: RNTP
     // maps KEYCODE_MEDIA_PLAY_PAUSE to it and reports the key handled, so
     // media3 never resolves the toggle into a play or a pause of its own.
-    it("is handled at all", async () => {
+    it("is subscribed to at all", async () => {
       await expect(handlerFor(Event.RemotePlayPause)).resolves.toBeDefined();
     });
 
     it("pauses when playing", async () => {
       const handler = await handlerFor(Event.RemotePlayPause);
       const playthrough = await loadPlaythrough(50);
-      setPlaying(true);
+
+      await Player.play(PlayPauseSource.USER);
+      await flushNativeEvents();
+      expect(useTrackPlayer.getState().isPlaying.playing).toBe(true);
 
       await handler();
 
-      expect(mockTrackPlayerPause).toHaveBeenCalled();
-      expect(mockTrackPlayerPlay).not.toHaveBeenCalled();
+      expect(trackPlayerFake.getState().playbackState).toBe("paused");
 
       const { lastPlayPause } = useTrackPlayer.getState();
       expect(lastPlayPause?.type).toBe(PlayPauseType.PAUSE);
@@ -124,12 +136,12 @@ describe("playback-service", () => {
     it("plays when paused", async () => {
       const handler = await handlerFor(Event.RemotePlayPause);
       await loadPlaythrough(50);
-      setPlaying(false);
+
+      expect(useTrackPlayer.getState().isPlaying.playing).toBe(false);
 
       await handler();
 
-      expect(mockTrackPlayerPlay).toHaveBeenCalled();
-      expect(mockTrackPlayerPause).not.toHaveBeenCalled();
+      expect(trackPlayerFake.getState().playbackState).toBe("playing");
 
       const { lastPlayPause } = useTrackPlayer.getState();
       expect(lastPlayPause?.type).toBe(PlayPauseType.PLAY);
@@ -139,7 +151,9 @@ describe("playback-service", () => {
     it("rewinds on pause, like every other pause", async () => {
       const handler = await handlerFor(Event.RemotePlayPause);
       await loadPlaythrough(100);
-      setPlaying(true);
+
+      await Player.play(PlayPauseSource.USER);
+      await flushNativeEvents();
 
       await handler();
 
@@ -156,7 +170,10 @@ describe("playback-service", () => {
 
       await handler();
 
-      expect(mockTrackPlayerPlay).toHaveBeenCalled();
+      expect(trackPlayerFake.getState().playbackState).toBe("playing");
+      expect(useTrackPlayer.getState().lastPlayPause?.type).toBe(
+        PlayPauseType.PLAY,
+      );
       expect(useTrackPlayer.getState().lastPlayPause?.source).toBe(
         PlayPauseSource.REMOTE,
       );
@@ -166,9 +183,15 @@ describe("playback-service", () => {
       const handler = await handlerFor(Event.RemotePause);
       await loadPlaythrough(50);
 
+      await Player.play(PlayPauseSource.USER);
+      await flushNativeEvents();
+
       await handler();
 
-      expect(mockTrackPlayerPause).toHaveBeenCalled();
+      expect(trackPlayerFake.getState().playbackState).toBe("paused");
+      expect(useTrackPlayer.getState().lastPlayPause?.type).toBe(
+        PlayPauseType.PAUSE,
+      );
       expect(useTrackPlayer.getState().lastPlayPause?.source).toBe(
         PlayPauseSource.REMOTE,
       );

--- a/src/services/playback-service.ts
+++ b/src/services/playback-service.ts
@@ -128,9 +128,27 @@ export const PlaybackService = async function () {
   //   log.debug("RemotePlayId", args);
   // });
 
-  // TrackPlayer.addEventListener(Event.RemotePlayPause, () => {
-  //   log.debug("RemotePlayPause");
-  // });
+  // A headset's play/pause key arrives here, and only here. RNTP maps
+  // KEYCODE_MEDIA_PLAY_PAUSE straight to this event and reports the key
+  // handled (`MusicService.onMediaKeyEvent`), so media3 never gets to resolve
+  // the toggle against playback state into a play or a pause of its own.
+  // Without this listener the key does nothing at all - and does it silently,
+  // because the notification's button takes the other route, through the
+  // media session, and arrives as RemotePlay/RemotePause.
+  //
+  // The toggle is resolved here instead, against the same isPlaying the
+  // notification's own button is drawn from.
+  TrackPlayer.addEventListener(Event.RemotePlayPause, async () => {
+    log.debug("RemotePlayPause");
+
+    const { playing } = Player.isPlaying();
+
+    if (playing) {
+      await Player.pause(PlayPauseSource.REMOTE, PAUSE_REWIND_SECONDS);
+    } else {
+      await Player.play(PlayPauseSource.REMOTE);
+    }
+  });
 
   // TrackPlayer.addEventListener(Event.RemotePlaySearch, (args) => {
   //   log.debug("RemotePlaySearch", args);


### PR DESCRIPTION
A Bluetooth headset's play/pause button intermittently did nothing while the
notification's own button kept working. It was not intermittent — it was one of
two input routes being unhandled, and only headsets take that route.

## The mechanism

RNTP's media session never touches the player. `InnerForwardingPlayer`
(`BaseAudioPlayer.kt`) overrides `play()` and `pause()` to emit an event and
wait for us to issue the command, so every remote control is a round trip
through JS. If the JS side drops the event, ExoPlayer carries on playing and
the button looks dead.

There are two ways in:

| Route | Event | Handled before this PR |
|---|---|---|
| Notification button → media session → `ForwardingPlayer.play()`/`pause()` | `remote-play` / `remote-pause` | yes |
| Headset key → `MusicService.onMediaKeyEvent` | `remote-play-pause` | **no** |

`onMediaKeyEvent` maps `KEYCODE_MEDIA_PLAY_PAUSE` to `remote-play-pause` and
returns `true`, reporting the key handled — so media3 never gets to resolve the
toggle against playback state into a play or a pause of its own. We listened for
neither, having left `Event.RemotePlayPause` commented out. That key did nothing
at all.

## The fix

Resolve the toggle in the handler, against the same `isPlaying` the
notification's button is drawn from, and route it to the same
`Player.play`/`Player.pause` the other two handlers use — so a remote pause
still rewinds by `PAUSE_REWIND_SECONDS`, like every other pause.

## Testing

New `src/services/__tests__/playback-service.test.ts`, firing events through the
handlers the service actually registers. Reverting the source change fails the
four `RemotePlayPause` cases and leaves the two notification-route cases green,
which is precisely the asymmetry this is about.

`npx jest src/services`: 229 passed across 17 suites. `npx tsc --noEmit` and
`npm run lint` clean.

## What this does not explain

I could not reproduce the original report on demand, and I cannot show from the
code why the same headphones would sometimes send `KEYCODE_MEDIA_PLAY_PAUSE`
and sometimes the state-specific `KEYCODE_MEDIA_PLAY`/`PAUSE`. The other
candidate for the same symptom is the media key being routed to another app's
`MediaSession` entirely — Android sends it to the most recently active one, and
the notification button cannot be misrouted that way, which fits the symptom
pair just as well.

So this closes a path that provably could never work, rather than a confirmed
root cause. If a headset button dies again after this ships,
`adb shell dumpsys media_session | grep -B2 -A8 "Media button session"` says
whether Ambry owns the key at that moment, and the answer is then routing.
