### PR TITLE
A failed seek was closing the seek lock for good

### DIFF
--- a/src/services/__tests__/seek-service.test.ts
+++ b/src/services/__tests__/seek-service.test.ts
@@ -23,7 +23,11 @@ import {
 } from "@/stores/track-player";
 import { setupTestDatabase } from "@test/db-test-utils";
 import { createMedia, DEFAULT_TEST_SESSION } from "@test/factories";
-import { resetTrackPlayerFake, trackPlayerFake } from "@test/jest-setup";
+import {
+  mockTrackPlayerSeekTo,
+  resetTrackPlayerFake,
+  trackPlayerFake,
+} from "@test/jest-setup";
 
 // Set up fresh test DB
 const { getDb } = setupTestDatabase();
@@ -284,6 +288,61 @@ describe("seek-service", () => {
 
       // First seek should have been applied
       expect(trackPlayerFake.getState().position).toBe(150);
+    });
+  });
+
+  describe("a seek that fails", () => {
+    // `isApplying` gates every entry point here, and it used to be cleared
+    // only on the success path - so one rejected seek shut the whole module
+    // for the life of the process.
+    const failOnce = () =>
+      mockTrackPlayerSeekTo.mockRejectedValueOnce(
+        new Error("player lost its track"),
+      );
+
+    it("releases the lock, so later seeks still apply", async () => {
+      await setupLoadedPlaythrough({ position: 100 });
+      failOnce();
+
+      await seekService.seekTo(150, SeekSource.SCRUBBER);
+      await jest.runAllTimersAsync();
+
+      // The failed seek did not move the player
+      expect(trackPlayerFake.getState().position).toBe(100);
+
+      // ...and the next one is not swallowed
+      await seekService.seekTo(200, SeekSource.SCRUBBER);
+      await jest.runAllTimersAsync();
+
+      expect(trackPlayerFake.getState().position).toBe(200);
+    });
+
+    it("clears the seeking UI instead of leaving the scrubber mid-drag", async () => {
+      await setupLoadedPlaythrough({ position: 100 });
+      failOnce();
+
+      await seekService.seekTo(150, SeekSource.SCRUBBER);
+      expect(useSeekUIState.getState().userIsSeeking).toBe(true);
+
+      await jest.runAllTimersAsync();
+
+      expect(useSeekUIState.getState().userIsSeeking).toBe(false);
+      expect(useSeekUIState.getState().seekPosition).toBeNull();
+    });
+
+    it("does not swallow a relative seek either", async () => {
+      await setupLoadedPlaythrough({ position: 100 });
+      failOnce();
+
+      await seekService.seekRelative(10, SeekSource.BUTTON);
+      await jest.runAllTimersAsync();
+
+      expect(trackPlayerFake.getState().position).toBe(100);
+
+      await seekService.seekRelative(10, SeekSource.BUTTON);
+      await jest.runAllTimersAsync();
+
+      expect(trackPlayerFake.getState().position).toBe(110);
     });
   });
 

--- a/src/services/seek-service.ts
+++ b/src/services/seek-service.ts
@@ -134,12 +134,23 @@ async function applyAccumulatedSeek(source: SeekSourceType) {
 
   log.debug(`Applying seek to ${positionToApply.toFixed(1)}`);
 
-  await Player.seekTo(positionToApply, source);
+  try {
+    await Player.seekTo(positionToApply, source);
+  } catch (error) {
+    // The lock and the seeking UI both outlive a failed seek without this.
+    // `isApplying` gates every entry point in this module, so a single
+    // rejected seek - a player that lost its track, a stream that cannot be
+    // reached - swallows every later seek for the life of the process, with
+    // the scrubber left mid-drag. Nothing upstream can catch it either: this
+    // runs from a background timer whose callback returns void, so the
+    // rejection surfaces as an unhandled one and the lock stays shut.
+    log.error("Seek failed, releasing the seek lock", error);
+  } finally {
+    // Clear UI seeking state
+    clearSeekUI();
 
-  // Clear UI seeking state
-  clearSeekUI();
-
-  isApplying = false;
+    isApplying = false;
+  }
 }
 
 /**


### PR DESCRIPTION
Found while tracing the headset play/pause path in #88. Unrelated failure mode,
separate PR.

## The bug

`isApplying` gates every entry point in `seek-service` — `seekTo`,
`seekRelative` and `applyAccumulatedSeek` all return early while it is set —
and it was cleared only on the success path:

```ts
await Player.seekTo(positionToApply, source);
clearSeekUI();
isApplying = false;
```

One rejected `Player.seekTo` — a player that lost its track, a stream that
cannot be reached — left it `true` for the life of the process. From then on the
scrubber, the ±10s buttons and the notification's jump buttons all silently did
nothing, with the seeking UI frozen mid-drag because `clearSeekUI` sat on the
same path. Play/pause kept working, which is what would make it puzzling to hit.

Nothing upstream could catch it either: `applyAccumulatedSeek` runs from a
background timer whose callback returns `void`, so the rejection surfaced as an
unhandled one and the lock stayed shut.

## The fix

Release the lock and the UI in a `finally`, and log the failure rather than
re-throwing, since there is nobody above to hear it.

## Testing

Three new cases under `a seek that fails`, driving the failure through the
native mock rather than reaching into the module.

Worth noting what reverting the source does to the suite: the three new cases
fail **and so do four that follow them**, because the module-level flag stays
set across tests exactly as it stayed set across a session. That cascade is the
bug in miniature — `seek-service` has no `resetForTesting()`, so the tests share
the flag the way the app does.

I left it that way rather than adding a reset helper, since the cascade is the
clearest evidence the fix works. Happy to add one if you would rather the file
be hermetic.

Full suite: 835 passed across 79 suites. `npx tsc --noEmit` and `npm run lint`
clean.
